### PR TITLE
feat: NotificationRepository 구현

### DIFF
--- a/src/main/java/com/kube/noon/notification/converter/NotificationTypeConverter.java
+++ b/src/main/java/com/kube/noon/notification/converter/NotificationTypeConverter.java
@@ -3,6 +3,11 @@ package com.kube.noon.notification.converter;
 import com.kube.noon.notification.domain.NotificationType;
 import jakarta.persistence.AttributeConverter;
 
+/**
+ * NotificationType을 데이터베이스에 저장하기 위한 데이터 컨버터
+ * NotificationType enum을 String 객체로 변환
+ * @author PGD
+ */
 public class NotificationTypeConverter
         implements AttributeConverter<NotificationType, String> {
 

--- a/src/main/java/com/kube/noon/notification/converter/NotificationTypeConverter.java
+++ b/src/main/java/com/kube/noon/notification/converter/NotificationTypeConverter.java
@@ -1,0 +1,18 @@
+package com.kube.noon.notification.converter;
+
+import com.kube.noon.notification.domain.NotificationType;
+import jakarta.persistence.AttributeConverter;
+
+public class NotificationTypeConverter
+        implements AttributeConverter<NotificationType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(NotificationType attribute) {
+        return attribute.name();
+    }
+
+    @Override
+    public NotificationType convertToEntityAttribute(String dbData) {
+        return NotificationType.valueOf(dbData);
+    }
+}

--- a/src/main/java/com/kube/noon/notification/domain/Notification.java
+++ b/src/main/java/com/kube/noon/notification/domain/Notification.java
@@ -1,0 +1,36 @@
+package com.kube.noon.notification.domain;
+
+import com.kube.noon.notification.converter.NotificationTypeConverter;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+@Entity
+@Table(name = "notification")
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Integer notificationId;
+
+    // TODO: receiverId -> receiver
+    @Column(name = "receiver_id", nullable = false)
+    private String receiverId;
+
+    @Column(name = "notification_text", nullable = false)
+    private String notificationText;
+
+    @Column(name = "notification_type", nullable = false)
+    @Convert(converter = NotificationTypeConverter.class)
+    private NotificationType notificationType;
+
+    public Notification(String receiverId, String notificationText, NotificationType notificationType) {
+        this.receiverId = receiverId;
+        this.notificationText = notificationText;
+        this.notificationType = notificationType;
+    }
+}

--- a/src/main/java/com/kube/noon/notification/domain/Notification.java
+++ b/src/main/java/com/kube/noon/notification/domain/Notification.java
@@ -4,6 +4,9 @@ import com.kube.noon.notification.converter.NotificationTypeConverter;
 import jakarta.persistence.*;
 import lombok.*;
 
+/**
+ * @author PGD
+ */
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/kube/noon/notification/domain/NotificationType.java
+++ b/src/main/java/com/kube/noon/notification/domain/NotificationType.java
@@ -3,9 +3,11 @@ package com.kube.noon.notification.domain;
 /**
  * COMMENT: 댓글 알림
  * LIKE: 좋아요 알림
+ * REPORT: 신고 알림
  * @author PGD
  */
 public enum NotificationType {
     COMMENT,
-    LIKE
+    LIKE,
+    REPORT
 }

--- a/src/main/java/com/kube/noon/notification/domain/NotificationType.java
+++ b/src/main/java/com/kube/noon/notification/domain/NotificationType.java
@@ -1,0 +1,6 @@
+package com.kube.noon.notification.domain;
+
+public enum NotificationType {
+    COMMENT,
+    LIKE
+}

--- a/src/main/java/com/kube/noon/notification/domain/NotificationType.java
+++ b/src/main/java/com/kube/noon/notification/domain/NotificationType.java
@@ -1,5 +1,10 @@
 package com.kube.noon.notification.domain;
 
+/**
+ * COMMENT: 댓글 알림
+ * LIKE: 좋아요 알림
+ * @author PGD
+ */
 public enum NotificationType {
     COMMENT,
     LIKE

--- a/src/main/java/com/kube/noon/notification/dto/NotificationDto.java
+++ b/src/main/java/com/kube/noon/notification/dto/NotificationDto.java
@@ -1,0 +1,17 @@
+package com.kube.noon.notification.dto;
+
+import com.kube.noon.notification.domain.NotificationType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class NotificationDto {
+    private String receiverId;
+    private String notificationText;
+    private NotificationType notificationType;
+}

--- a/src/main/java/com/kube/noon/notification/dto/NotificationDto.java
+++ b/src/main/java/com/kube/noon/notification/dto/NotificationDto.java
@@ -6,6 +6,9 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * @author PGD
+ */
 @NoArgsConstructor
 @Getter
 @Setter

--- a/src/main/java/com/kube/noon/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/kube/noon/notification/repository/NotificationRepository.java
@@ -1,0 +1,8 @@
+package com.kube.noon.notification.repository;
+
+import com.kube.noon.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository
+        extends JpaRepository<Notification, Integer> {
+}

--- a/src/main/java/com/kube/noon/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/kube/noon/notification/repository/NotificationRepository.java
@@ -3,6 +3,9 @@ package com.kube.noon.notification.repository;
 import com.kube.noon.notification.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+/**
+ * @author PGD
+ */
 public interface NotificationRepository
         extends JpaRepository<Notification, Integer> {
 }

--- a/src/main/java/com/kube/noon/notification/service/NotificationService.java
+++ b/src/main/java/com/kube/noon/notification/service/NotificationService.java
@@ -1,0 +1,10 @@
+package com.kube.noon.notification.service;
+
+import com.kube.noon.notification.dto.NotificationDto;
+
+public interface NotificationService {
+
+    public void sendNotification(NotificationDto notification);
+
+    public NotificationDto getNotification(String notificationId);
+}

--- a/src/main/java/com/kube/noon/notification/service/NotificationService.java
+++ b/src/main/java/com/kube/noon/notification/service/NotificationService.java
@@ -2,9 +2,22 @@ package com.kube.noon.notification.service;
 
 import com.kube.noon.notification.dto.NotificationDto;
 
+/**
+ * @author PGD
+ */
 public interface NotificationService {
 
+    /**
+     * 알림을 전송한다.
+     * 전송된 알림은 데이터베이스에 저장된다.
+     * @param notification 전송할 알림 데이터가 담긴 DTO 객체
+     */
     public void sendNotification(NotificationDto notification);
 
+    /**
+     * 알림을 조회한다.
+     * @param notificationId 알림의 ID
+     * @return notificationId로 식별되는 알림 데이터 DTO 객체
+     */
     public NotificationDto getNotification(String notificationId);
 }

--- a/src/main/java/com/kube/noon/places/repository/PlacesNaverMapsApiRepositoryImpl.java
+++ b/src/main/java/com/kube/noon/places/repository/PlacesNaverMapsApiRepositoryImpl.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 @Slf4j
 @Repository
-public class PlacesNaverMapsApiRepository implements PlacesRepository {
+public class PlacesNaverMapsApiRepositoryImpl implements PlacesRepository {
     private static final String GEOCODE_ACCESS_KEY_HEADER = "X-NCP-APIGW-API-KEY-ID";
     private static final String GEOCODE_SECRET_KEY_HEADER = "X-NCP-APIGW-API-KEY";
     private static final String NAVER_CLOUD_GEOCODE_API_URL = "https://naveropenapi.apigw.ntruss.com/map-geocode/v2/geocode";
@@ -45,7 +45,7 @@ public class PlacesNaverMapsApiRepository implements PlacesRepository {
     private final String secretKey;
     private final RestTemplate restTemplate;
 
-    public PlacesNaverMapsApiRepository(
+    public PlacesNaverMapsApiRepositoryImpl(
             @Value("${geocode.naver.access-key}") String accessKey,
             @Value("${geocode.naver.secret-key}") String secretKey
     ) {

--- a/src/main/java/com/kube/noon/places/repository/PlacesRepository.java
+++ b/src/main/java/com/kube/noon/places/repository/PlacesRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface PlacesRepository {
 
-    List<Place> findByPlaceName(String placeName);
+    public List<Place> findByPlaceName(String placeName);
 
     public Place findByPosition(double latitude, double longitude) throws PlaceNotFoundException;
 }

--- a/src/main/java/com/kube/noon/places/service/PlacesService.java
+++ b/src/main/java/com/kube/noon/places/service/PlacesService.java
@@ -2,6 +2,7 @@ package com.kube.noon.places.service;
 
 import com.kube.noon.places.dto.PlaceDto;
 import com.kube.noon.places.exception.PlaceNotFoundException;
+import com.kube.noon.places.repository.PlacesNaverMapsApiRepositoryImpl;
 
 import java.util.List;
 
@@ -12,7 +13,7 @@ import java.util.List;
  *
  * @author pgd
  * @see com.kube.noon.places.repository.PlacesRepository
- * @see com.kube.noon.places.repository.PlacesNaverMapsApiRepository
+ * @see PlacesNaverMapsApiRepositoryImpl
  * @see com.kube.noon.places.domain.Place
  * @see PlaceDto
  * @see PlacesServiceImpl
@@ -24,7 +25,7 @@ public interface PlacesService {
      * @param searchKeyword 장소 검색 키워드
      * @return searchKeyword에 부합하는 장소들을 반환. 반환되는 List의 길이는 1보다 클 수 있고, 1일 수 있고, 0일 수 있다.
      */
-    List<PlaceDto> getPlaceList(String searchKeyword);
+    public List<PlaceDto> getPlaceList(String searchKeyword);
 
     /**
      * 주어진 위도, 경도에 위치한 장소 정보를 얻는다.
@@ -33,5 +34,5 @@ public interface PlacesService {
      * @return latitude, longitude에 위치한 장소의 정보
      * @throws PlaceNotFoundException 주어진 latitude, longitude에 위치한 장소가 없을 경우
      */
-    PlaceDto getPlaceByPosition(double latitude, double longitude) throws PlaceNotFoundException;
+    public PlaceDto getPlaceByPosition(double latitude, double longitude) throws PlaceNotFoundException;
 }

--- a/src/test/java/com/kube/noon/notification/repository/TestNotificationRepository.java
+++ b/src/test/java/com/kube/noon/notification/repository/TestNotificationRepository.java
@@ -1,0 +1,116 @@
+package com.kube.noon.notification.repository;
+
+import com.kube.noon.notification.domain.Notification;
+import com.kube.noon.notification.domain.NotificationType;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.jdbc.support.JdbcUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@Slf4j
+@SpringBootTest
+@Transactional
+public class TestNotificationRepository {
+
+    @Autowired
+    DataSource dataSource;
+
+    @Autowired
+    NotificationRepository notificationRepository;
+
+    @BeforeEach
+    void init() {
+        // 참조 무결성을 위해 members 테이블에 데이터 삽입
+        String sql = """
+                INSERT INTO members (
+                    member_id,
+                    nickname,
+                    pwd,
+                    phone_number,
+                    building_subscription_public_range,
+                    all_feed_public_range,
+                    member_profile_public_range,
+                    receiving_all_notification_allowed
+                ) VALUES (
+                    'sample-receiver',
+                    'sample-nickname',
+                    'sample-pwd',
+                    '01012341234',
+                    'PUBLIC',
+                    'PUBLIC',
+                    'PUBLIC',
+                    TRUE
+                )
+                """;
+
+        Connection conn = null;
+        PreparedStatement stmt = null;
+
+        try {
+            conn = DataSourceUtils.getConnection(this.dataSource);
+            stmt = conn.prepareStatement(sql);
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (stmt != null) {
+                JdbcUtils.closeStatement(stmt);
+            }
+
+            if (conn != null) {
+                // 트랜잭션이 끝나기 전까지 Connection을 클로즈하지 않기 위해
+                DataSourceUtils.releaseConnection(conn, this.dataSource);
+            }
+        }
+    }
+
+    @DisplayName("Notification 저장")
+    @Test
+    void save() {
+        Notification testCase =
+                new Notification("sample-receiver", "sample-text", NotificationType.COMMENT);
+        assertThatNoException().isThrownBy(() -> this.notificationRepository.save(testCase));
+
+        Integer notificationId = testCase.getNotificationId();
+
+        assertThat(notificationId).isNotNull();
+    }
+
+    @DisplayName("Notification 조회")
+    @Test
+    void findById() {
+        Notification testCase =
+                new Notification("sample-receiver", "sample-text", NotificationType.COMMENT);
+
+        this.notificationRepository.save(testCase);
+
+        Integer notificationId = testCase.getNotificationId();
+
+        Optional<Notification> findNotificationOp = this.notificationRepository.findById(notificationId);
+
+        assertThat(findNotificationOp.isPresent()).isTrue();
+
+        Notification findNotification = findNotificationOp.get();
+
+        log.info("findNotification={}", findNotification);
+
+        assertThat(findNotification.getNotificationId()).isEqualTo(testCase.getNotificationId());
+        assertThat(findNotification.getReceiverId()).isEqualTo(testCase.getReceiverId());
+        assertThat(findNotification.getNotificationText()).isEqualTo(testCase.getNotificationText());
+        assertThat(findNotification.getNotificationType()).isEqualTo(testCase.getNotificationType());
+    }
+}

--- a/src/test/java/com/kube/noon/notification/repository/TestNotificationRepository.java
+++ b/src/test/java/com/kube/noon/notification/repository/TestNotificationRepository.java
@@ -21,6 +21,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
+/**
+ * @author PGD
+ */
 @Slf4j
 @SpringBootTest
 @Transactional

--- a/src/test/java/com/kube/noon/places/repository/TestPlacesNaverMapsApiRepositoryImpl.java
+++ b/src/test/java/com/kube/noon/places/repository/TestPlacesNaverMapsApiRepositoryImpl.java
@@ -15,10 +15,10 @@ import java.util.stream.Stream;
 
 @Slf4j
 @SpringBootTest
-class TestPlacesNaverMapsApiRepository {
+class TestPlacesNaverMapsApiRepositoryImpl {
 
     @Autowired
-    PlacesNaverMapsApiRepository placesRepository;
+    PlacesNaverMapsApiRepositoryImpl placesRepository;
 
     @DisplayName("장소명으로 도로명주소, 위도, 경도 가져오기 테스트")
     @Test


### PR DESCRIPTION
## 요약
알림을 데이터베이스에 저장하는 NotificationRepository 구현

## 변경 사항 설명
- Notifcation, NotificationType 객체 구현
- JPA 기반 NotificationRepository 구현
- NotifcationRepository 테스트 코드 작성
- places 서브시스템 리팩토링

## 관련 이슈 및 참고 자료
Issue: #22 

### 참조1
[AttributeConverter 설명](https://velog.io/@ewan/JPA-AttributeConverter-%EC%9D%84-%EC%82%AC%EC%9A%A9%ED%95%9C-%EC%97%94%ED%8B%B0%ED%8B%B0-%EA%B5%AC%EC%84%B1)

### 참조2
참조 무결성을 위해 members 테이블에 데이터를 추가해야 하는데 MemberRepository가 없는 관계로 기본 JDBC 코드로 members 테이블에 레코드를 넣었습니다.
이때 트랜잭션을 유지하기 위해 DataSourceUtils를 사용했는데 DataSourceUtils에 대해서 학습하면 좋을 것 같습니다. DataSourceUtils는 테스트 코드에만 나타나므로 필수적으로 학습할 필요는 없습니다.
[DataSourceUtils API](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/jdbc/datasource/DataSourceUtils.html)
[스프링 DB 접근 기술 - 순수 JDBC](https://m.blog.naver.com/adamdoha/222078797274)
