### PR TITLE
feat : Winterhana/#32/feed sql : 피드와 관련된 JPA 코드 추가 및 테스트 완료

### DIFF
--- a/src/main/java/com/kube/noon/common/zzim/Zzim.java
+++ b/src/main/java/com/kube/noon/common/zzim/Zzim.java
@@ -25,7 +25,7 @@ public class Zzim {
     @Column(name = "building_id", nullable = false)
     private int buildingId;
 
-    @Column(name = "subscription_provider_id", nullable = false, length = 20)
+    @Column(name = "subscription_provider_id", length = 20)
     private String subscriptionProviderId;
 
     @Enumerated(EnumType.STRING)
@@ -34,4 +34,8 @@ public class Zzim {
 
     @Column(name = "activated")
     private boolean activated;
+
+    public void setActivated(boolean activated) {
+        this.activated = activated;
+    }
 }

--- a/src/main/java/com/kube/noon/common/zzim/ZzimRepository.java
+++ b/src/main/java/com/kube/noon/common/zzim/ZzimRepository.java
@@ -48,4 +48,13 @@ public interface ZzimRepository extends JpaRepository<Zzim, Integer> {
      * @author 허예지
      */
     Zzim findByBuildingIdAndMemberId(int buildingId, String memberId);
+
+    /**
+     * 피드 아이디, 유저 아이디, 찜 타입을 통해 Zzim Table의 데이터를 확인한다.
+     * @param feedId
+     * @param memberId
+     * @param zzimType
+     * @return Zzim 해당하는 Zzim 하나를 가져온다.
+     */
+    Zzim findByFeedIdAndMemberIdAndZzimType(int feedId, String memberId, ZzimType zzimType);
 }

--- a/src/main/java/com/kube/noon/feed/repository/FeedAttachmentRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/FeedAttachmentRepository.java
@@ -7,7 +7,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface FeedAttachmentRepository extends JpaRepository<FeedAttachment, Long> {
+    /**
+     * 피드의 첨부파일을 가져온다.
+     * @param feed
+     * @return
+     */
     List<FeedAttachment> findByFeed(Feed feed);
 
+    /**
+     * 첨부파일 아이디로 첨부파일을 찾는다.
+     * @param attachmentId
+     * @return
+     */
     FeedAttachment findByAttachmentId(int attachmentId);
 }

--- a/src/main/java/com/kube/noon/feed/repository/FeedCommentRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/FeedCommentRepository.java
@@ -7,7 +7,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface FeedCommentRepository extends JpaRepository<FeedComment, Long> {
+    /**
+     * 피드의 댓글 리스트를 가져온다.
+     * @param feed
+     * @return
+     */
     List<FeedComment> findByFeed(Feed feed);
 
+    /**
+     * 댓글 아이디로 댓글을 가져온다.
+     * @param commentId
+     * @return
+     */
     FeedComment findByCommentId(int commentId);
 }

--- a/src/main/java/com/kube/noon/feed/repository/FeedRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/FeedRepository.java
@@ -3,15 +3,16 @@ package com.kube.noon.feed.repository;
 import com.kube.noon.building.domain.Building;
 import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.member.domain.Member;
-import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface FeedRepository extends JpaRepository<Feed, Long> {
     /**
      * 하나에 피드에 대한 상세보기를 제공한다.
+     *
      * @param feedId : PK인 feedId를 받는다.
      * @return Feed : Feed repository를 반환받는다.
      */
@@ -19,12 +20,14 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     /**
      * 전체 저장된 피드를 가져온다. 단, 활성화가 된 피드만 가져온다.
+     *
      * @return List<Feed>
      */
     List<Feed> findByActivatedTrue();
 
     /**
      * 회원별로 작성한 피드를 가져온다. 단, 활성화가 된 피드만 가져온다.
+     *
      * @param writer 회원ID를 받는다.
      * @return List<Feed>
      */
@@ -32,12 +35,14 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     /**
      * 건물별로 작성된 피드를 가져온다. 단, 활성화가 된 피드만 가져온다.
+     *
      * @return List<Feed>
      */
     List<Feed> findByBuildingAndActivatedTrue(Building building);
 
     /**
      * 회원의 메인 피드를 가져온다.
+     *
      * @param writer 대상 회원을 받는다.
      * @return Feed 회원의 메인 피드를 가져온다.
      */
@@ -45,33 +50,62 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     /**
      * 회원이 좋아요를 누른 피드 목록을 가져온다. 단, 활성화가 된 피드만 가져온다.
+     *
      * @param member Member 객체를 받는다.
      * @return List<Feed>
      */
-    @Query("SELECT f FROM Feed f " +
-            "INNER JOIN Zzim z ON f.feedId = z.feedId " +
-            "WHERE z.zzimType = 'LIKE' AND z.memberId = :#{#member.memberId} AND f.activated = true AND z.activated = true")
+    @Query("""
+            SELECT f FROM Feed f 
+            INNER JOIN Zzim z ON f.feedId = z.feedId 
+            WHERE z.zzimType = 'LIKE' AND z.memberId = :#{#member.memberId} AND f.activated = true AND z.activated = true
+           """)
     List<Feed> findByMemberLikeFeed(@Param("member") Member member);
 
     /**
      * 회원이 북마크를 한 피드 목록을 가져온다. 단, 활성화가 된 피드만 가져온다.
+     *
      * @param member Member 객체를 받는다.
      * @return List<Feed>
      */
-    @Query("SELECT f FROM Feed f " +
-            "INNER JOIN Zzim z ON f.feedId = z.feedId " +
-            "WHERE z.zzimType = 'BOOKMARK' AND z.memberId = :#{#member.memberId} AND f.activated = true AND z.activated = true")
+    @Query("""
+            SELECT f FROM Feed f 
+            INNER JOIN Zzim z ON f.feedId = z.feedId 
+            WHERE z.zzimType = 'BOOKMARK' AND z.memberId = :#{#member.memberId} AND f.activated = true AND z.activated = true 
+           """)
     List<Feed> findByMemberBookmarkFeed(@Param("member") Member member);
 
     /**
      * 회원이 구독한 건물에 대한 피드 목록을 가져온다. 단, 활성화가 된 피드만 가져온다.
+     *
      * @param member Member 객체를 받는다.
      * @return List<Feed>
      */
-    @Query("SELECT f FROM Feed f " +
-            "INNER JOIN Zzim z ON f.building.buildingId = z.buildingId " +
-            "WHERE z.zzimType = 'SUBSCRIPTION' AND z.memberId = :#{#member.memberId} AND f.activated = true AND z.activated = true")
+    @Query("""
+            SELECT f FROM Feed f 
+            INNER JOIN Zzim z ON f.building.buildingId = z.buildingId 
+            WHERE z.zzimType = 'SUBSCRIPTION' AND z.memberId = :#{#member.memberId} AND f.activated = true AND z.activated = true
+           """)
     List<Feed> findByMemberBuildingSubscription(@Param("member") Member member);
 
+    /**
+     * 피드에 좋아요를 누른 맴버의 목록을 가져옵니다.
+     *
+     * @param feed
+     * @return List<Member>
+     */
+    @Query("""
+            SELECT m FROM Member m 
+            INNER JOIN Zzim z ON m.memberId = z.memberId 
+            WHERE z.feedId = :#{#feed.feedId} AND z.zzimType = 'LIKE'
+           """)
+    List<Member> getFeedLikeList(@Param("feed") Feed feed);
 
+    /**
+     * 제목이나 내용을 통해 피드를 검색할 수 있도록 합니다.
+     * @param keyword 검색할 keyword를 입력합니다.
+     * @return List<Feed>
+     */
+    List<Feed> findByFeedTextContainingIgnoreCase(String keyword);
+
+    List<Feed> findByTitleContainingIgnoreCase(String keyword);
 }

--- a/src/main/java/com/kube/noon/feed/repository/TagFeedRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/TagFeedRepository.java
@@ -1,10 +1,16 @@
 package com.kube.noon.feed.repository;
 
+import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.feed.domain.Tag;
 import com.kube.noon.feed.domain.TagFeed;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface TagFeedRepository extends JpaRepository<TagFeed, Long> {
-    int deleteByTag(Tag tag);
+    /**
+     * 연관 테이블의 태그를 삭제한다.
+     * @param tag
+     * @return
+     */
+     int deleteByTagAndFeed(Tag tag, Feed feed);
 }

--- a/src/main/java/com/kube/noon/feed/repository/TagRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/TagRepository.java
@@ -1,8 +1,32 @@
 package com.kube.noon.feed.repository;
 
+import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.feed.domain.Tag;
+import com.kube.noon.feed.dto.TagDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+    /**
+     * 각 피드에 붙어있는 피드의 내용을 가져온다.
+     * @param feed
+     * @return
+     */
+    @Query("""
+        SELECT t
+        FROM TagFeed f
+                 INNER JOIN Tag t ON f.tag.tagId = t.tagId
+        WHERE f.feed.feedId = :#{#feed.feedId}
+        """)
+    List<Tag> getTagByFeedId(@Param("feed") Feed feed);
+
+    /**
+     * 태그 택스트로 태그를 찾는다.
+     * @param tagText
+     * @return
+     */
     Tag findByTagText(String tagText);
 }

--- a/src/main/java/com/kube/noon/feed/repository/mybatis/TagMyBatisRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/mybatis/TagMyBatisRepository.java
@@ -7,5 +7,10 @@ import java.util.List;
 
 @Mapper
 public interface TagMyBatisRepository {
+    /**
+     * (deprecated)
+     * @param feedId
+     * @return
+     */
     List<TagDto> getTagByFeedId(int feedId);
 }

--- a/src/main/resources/mybatis-mapper/feed/TagMapper.xml
+++ b/src/main/resources/mybatis-mapper/feed/TagMapper.xml
@@ -14,5 +14,19 @@
                  INNER JOIN tag t ON f.tag_id = t.tag_id
         WHERE feed_id = 10000;
     </select>
+<!--    전에 쓰던 로직 개선하여 사용할 예정입니다. -->
+<!--    <select id = "getFeedCountByTagName"  resultMap = "productCountByTagMap">-->
+<!--        SELECT result.tag_name, COUNT(*) count FROM-->
+<!--            ( SELECT p.prod_name, t.tag_name FROM product p-->
+<!--            INNER JOIN product_tag pt ON pt.prod_no = p.prod_no-->
+<!--            INNER JOIN tag t ON t.tag_no = pt.tag_no ) result-->
+<!--        GROUP BY result.tag_name-->
+<!--    </select>-->
 
+<!--    <select id = "getProductCountByTransaction" resultMap = "productCountByTransactionMap">-->
+<!--        SELECT p.prod_name, result.count FROM product p-->
+<!--            INNER JOIN-->
+<!--            ( SELECT prod_no, COUNT(*) count FROM transaction_list GROUP BY prod_no ) result-->
+<!--            ON result.prod_no = p.prod_no-->
+<!--    </select>-->
 </mapper>

--- a/src/test/java/com/kube/noon/feed/repository/TestFeedAttachmentRepository.java
+++ b/src/test/java/com/kube/noon/feed/repository/TestFeedAttachmentRepository.java
@@ -62,7 +62,7 @@ public class TestFeedAttachmentRepository {
     }
 
     /**
-     * 피드에 첨부파일을 하나 삭제한다.
+     * 피드에 첨부파일을 하나 삭제한다. - activated = false
      * feed_id = 10000, attachment_id = 10000을 기준으로 한다.
      */
     @Transactional

--- a/src/test/java/com/kube/noon/feed/repository/TestTagFeedRepository.java
+++ b/src/test/java/com/kube/noon/feed/repository/TestTagFeedRepository.java
@@ -38,7 +38,7 @@ public class TestTagFeedRepository {
     @Transactional
     @Test
     public void getFeedTagsTest() {
-        List<TagDto> getTagByFeedId = tagMyBatisRepository.getTagByFeedId(10000);
+        List<Tag> getTagByFeedId = tagRepository.getTagByFeedId(Feed.builder().feedId(10000).build());
 
         // test 1) 존재 여부 확인
         assertThat(getTagByFeedId).isNotNull();
@@ -75,23 +75,24 @@ public class TestTagFeedRepository {
 
     /**
      * 태그 하나를 삭제하는 과정을 테스트한다.
-     * feed_id = 10005, tag_id = 맛있다_6 을 기준으로 한다.
+     * tag_text = '행복', feed_id = 10000 을 기준으로 한다.
      */
     @Transactional
     @Test
     public void deleteTagTest() {
-        String tagText = "따듯함";
+        String tagText = "행복";
 
         // 1. 태그 텍스트에 대한 번호를 가져온다.
         Tag tag = tagRepository.findByTagText(tagText);
 
-        // 1-1. 만약 찾아서 없으면 종료
+        // 1-1. 만약 없으면 종료
         if(tag == null) {
             return;
         }
 
         // 2. 피드에 대한 태그를 삭제한다.
         // test 1) 정상 삭제 확인
-        assertThat(tagFeedRepository.deleteByTag(tag)).isEqualTo(1);
+        log.info(tag);
+        assertThat(tagFeedRepository.deleteByTagAndFeed(tag, Feed.builder().feedId(10000).build())).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## 요약
피드와 관련된 쿼리 관련 코드를 추가했습니다.

## 변경 사항 설명
- JPA 코드 추가 및 테스트를 추가하였습니다.
- 진행하는 과정에서 zzim Entity, repository가 조금 변경되었습니다. 하단의 [issue](https://github.com/kuberMAPtes/noon-main-api-server/issues/32)에 작성했으니 참고 부탁드립니다. 
- 현재 반영된 코드 내에 일부 쓸모없는 (또는 사용하지 않는) 코드가 있을겁니다. (사용하지 않는 lib import 등) 이는 다음 PR 때 수정하여 반영하겠습니다.
- 사용한 DB 초기화 코드는 [SQL docs Repository](https://github.com/kuberMAPtes/noon-sql-docs/blob/main/Winterhana/test_db_init_private.sql)에 올려두었으니 참고 부탁드립니다. DB 관리자님이 배포하신 것과 조금 다릅니다. 앞으로 사용한 SQL이 있으면 Repository 내의 `Winterhana` 폴더에 반영할 예정입니다.

## 관련 이슈 및 참고 자료
issue : #32 
