### PR TITLE
feat : 빌딩 피드 AI 요약 구현

### DIFF
--- a/src/main/java/com/kube/noon/building/repository/BuildingSummaryRepository.java
+++ b/src/main/java/com/kube/noon/building/repository/BuildingSummaryRepository.java
@@ -1,0 +1,5 @@
+package com.kube.noon.building.repository;
+
+public interface BuildingSummaryRepository {
+    String findFeedAISummary(String title, String feedText);
+}

--- a/src/main/java/com/kube/noon/building/repository/BuildingSummaryRepositoryImpl.java
+++ b/src/main/java/com/kube/noon/building/repository/BuildingSummaryRepositoryImpl.java
@@ -1,0 +1,69 @@
+package com.kube.noon.building.repository;
+
+import com.kube.noon.building.domain.Building;
+import com.kube.noon.feed.domain.Feed;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+@Repository
+public class BuildingSummaryRepositoryImpl implements BuildingSummaryRepository {
+
+
+    ///Field
+    private static final String SUMMARY_ACCESS_KEY_HEADER = "X-NCP-APIGW-API-KEY-ID";
+    private static final String SUMMARY_SECRET_KEY_HEADER = "X-NCP-APIGW-API-KEY";
+    private static final String CLOVA_SUMMARY_API_URL = "https://naveropenapi.apigw.ntruss.com/text-summary/v1/summarize";
+    private static final String SUMMARY_RESPONSE_LINE_COUNT = "1";// 1줄로 요약
+    private static final Logger log = LoggerFactory.getLogger(BuildingSummaryRepositoryImpl.class);
+
+    @Value("${summary.naver.access-key}")
+    private String accessKey;
+
+    @Value("${summary.naver.secret-key}")
+    private String secretKey ;
+
+
+    ///Method
+    @Override
+    public String findFeedAISummary(String title, String feedText) {
+
+        log.info("title={}", title);
+        log.info("feedText={}", feedText);
+
+        WebClient client = WebClient.create(CLOVA_SUMMARY_API_URL);
+
+        String requestBody = """
+                {
+                  "document": {
+                    "title": "%s",
+                    "content": "%s"
+                  },
+                  "option": {
+                    "language": "ko",
+                    "model": "news",
+                    "tone": 2,
+                    "summaryCount": %s
+                  }
+                }
+                """.formatted(title, feedText, SUMMARY_RESPONSE_LINE_COUNT);
+
+        log.info("requestBody={}", requestBody);
+
+
+        return client.post()
+                .header(SUMMARY_ACCESS_KEY_HEADER, this.accessKey)
+                .header(SUMMARY_SECRET_KEY_HEADER, secretKey)
+                .header("Content-Type", "application/json")
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block(); //테스트 코드에서는 동기식으로 작성함. 추후 수정
+
+
+    }
+}

--- a/src/main/java/com/kube/noon/building/service/BuildingProfileService.java
+++ b/src/main/java/com/kube/noon/building/service/BuildingProfileService.java
@@ -12,4 +12,7 @@ public interface BuildingProfileService {
     List<BuildingDto> getUserBuildingSubscriptionList(String memberId);
     BuildingDto getBuildingProfile(int buildingId);
     List<BuildingDto> getBuildingSubscriptionListByMemberId(String memberId);
+
+    String getFeedAISummary(int buildingId);
+
 }

--- a/src/main/java/com/kube/noon/building/service/BuildingProfileServiceImpl.java
+++ b/src/main/java/com/kube/noon/building/service/BuildingProfileServiceImpl.java
@@ -3,12 +3,16 @@ package com.kube.noon.building.service;
 import com.kube.noon.building.domain.Building;
 import com.kube.noon.building.dto.BuildingDto;
 import com.kube.noon.building.dto.BuildingZzimDto;
+import com.kube.noon.building.repository.BuildingSummaryRepository;
 import com.kube.noon.building.repository.mapper.BuildingProfileMapper;
 import com.kube.noon.building.repository.BuildingProfileRepository;
 import com.kube.noon.common.zzim.Zzim;
 import com.kube.noon.common.zzim.ZzimRepository;
 import com.kube.noon.common.zzim.ZzimType;
+import com.kube.noon.feed.domain.Feed;
+import com.kube.noon.feed.repository.FeedRepository;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -24,26 +28,19 @@ import java.util.stream.Collectors;
  * @author 허예지
  */
 @Service("buildingProfileServiceImpl")
+@RequiredArgsConstructor
 public class BuildingProfileServiceImpl implements BuildingProfileService {
 
 
     ///Field
-    @Autowired
-    @Qualifier("buildingProfileRepository")
-    private BuildingProfileRepository buildingProfileRepository;
+    private final BuildingProfileRepository buildingProfileRepository;
+    private final ZzimRepository zzimRepository;
+    private final BuildingProfileMapper buildingProfileMapper;
+    private final BuildingSummaryRepository buildingSummaryRepository;
+    private final FeedRepository feedRepository;
 
-    @Autowired
-    @Qualifier("zzimRepository")
-    private ZzimRepository zzimRepository;
-
-    @Autowired
-    @Qualifier("buildingProfileMapper")
-    private BuildingProfileMapper buildingProfileMapper;
-
-
-
-
-
+    public static final int SUMMARY_LENGTH_LIMIT = 2000;
+    public static final int SUMMARY_FEED_COUNT_LIMIT  = 10;
 
     ///Method
     /**
@@ -172,5 +169,39 @@ public class BuildingProfileServiceImpl implements BuildingProfileService {
         return buildings.stream()
                 .map(BuildingDto::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+
+    /**
+     * buildingId로 조회한 빌딩의 모든 피드를 가져와 3줄로 요약
+     * 임시데이터 피드 10개로 요약. 추후 피드 서비스인 '최신 피드목록 가져오기'로 대체
+     *
+     * @param buildingId 피드 요약을 하려는 빌딩의 아이디
+     * @return
+     */
+    @Override
+    public String getFeedAISummary(int buildingId) {
+
+        List<Feed> getFeedListByBuildingId = feedRepository.findByBuildingAndActivatedTrue(Building.builder().buildingId(buildingId).build());
+
+        String title = "";
+        String feedText = "";
+
+        for(Feed feed : getFeedListByBuildingId){
+
+            // CLOVA Summary 요약 글자 제한: 제목+내용 2000자
+            if( (title+feed.getTitle()+feedText+feed.getFeedText()).length() > SUMMARY_LENGTH_LIMIT ){
+
+                title="";
+                feedText = buildingSummaryRepository.findFeedAISummary(title, feedText);
+
+            }else{
+                title += (feed.getTitle()+". ");
+                feedText += (feed.getFeedText()+". ");
+            }
+
+        }///end of for
+
+        return buildingSummaryRepository.findFeedAISummary(title, feedText);
     }
 }

--- a/src/test/java/com/kube/noon/building/service/TestBuildingService.java
+++ b/src/test/java/com/kube/noon/building/service/TestBuildingService.java
@@ -1,6 +1,8 @@
 package com.kube.noon.building.service;
 import com.kube.noon.building.dto.BuildingDto;
 import com.kube.noon.building.dto.BuildingZzimDto;
+import com.kube.noon.building.repository.BuildingSummaryRepository;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,6 +60,13 @@ public class TestBuildingService {
             log.info("빌딩도로명주소={}", buildingDto.getRoadAddr());
 
         }
+
+    }
+    @DisplayName("건물아이디로 건물 피드 요약 보기")
+    @Test
+    void getFeedAISummary(){
+
+        log.info("빌딩피드 요약내용={}", buildingProfileService.getFeedAISummary(10099));
 
     }
 }

--- a/src/test/java/com/kube/noon/customersupport/repository/TestCustomerSupportRepository.java
+++ b/src/test/java/com/kube/noon/customersupport/repository/TestCustomerSupportRepository.java
@@ -6,7 +6,7 @@ import com.kube.noon.customersupport.dto.notice.NoticeDto;
 import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.feed.repository.FeedRepository;
 import com.kube.noon.member.domain.Member;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,7 +16,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Log4j2
+@Slf4j
 @SpringBootTest
 
 public class TestCustomerSupportRepository {

--- a/src/test/java/com/kube/noon/customersupport/repository/TestCustomerSupportRepository.java
+++ b/src/test/java/com/kube/noon/customersupport/repository/TestCustomerSupportRepository.java
@@ -1,0 +1,87 @@
+package com.kube.noon.customersupport.repository;
+
+import com.kube.noon.common.FeedCategory;
+import com.kube.noon.common.PublicRange;
+import com.kube.noon.customersupport.dto.notice.NoticeDto;
+import com.kube.noon.feed.domain.Feed;
+import com.kube.noon.feed.repository.FeedRepository;
+import com.kube.noon.member.domain.Member;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Log4j2
+@SpringBootTest
+
+public class TestCustomerSupportRepository {
+
+
+    @Autowired
+    private NoticeRepository noticeRepository;
+
+    @Autowired
+    private FeedRepository feedRepository;
+
+
+    /**
+     * 공지사항 목록을 가져온다. 삭제(activated=false)되지 않은 것만 가져온다.
+     *
+     */
+    @Test
+    void testfindNoticeList(){
+
+        List<Feed> noticeList = noticeRepository.findByFeedCategoryAndActivated(FeedCategory.NOTICE, true);
+
+        for(Feed notice : noticeList){
+            log.info("공지사항={}",NoticeDto.fromEntity(notice));
+        }
+
+    }
+
+
+    /**
+     * feedRepository를 이용해 Notice를 Add 또는 Delete
+     *
+     */
+    @Transactional
+    @Test
+    void testAddAndDeleteNotice() {
+
+        Member member = new Member();
+        member.setMemberId("member_1");
+
+        //Notice Add Test
+        Feed feed = Feed.builder()
+                .writer(member)
+                .building(null)
+                .mainActivated(false)
+                .publicRange(PublicRange.PUBLIC)
+                .title("Test Notice")
+                .feedText("This is Notice...")
+                .viewCnt(9999L)
+                .writtenTime(LocalDateTime.now())
+                .feedCategory(FeedCategory.NOTICE)
+                .modified(false)
+                .activated(true)
+                .build();
+
+        int noticeId = feedRepository.save(feed).getFeedId();
+        Feed getAddedFeed = feedRepository.findByFeedId(noticeId);
+        assertThat(getAddedFeed).isNotNull();
+
+
+        //Notice Delete Test
+        getAddedFeed.setActivated(false);
+        feedRepository.save(getAddedFeed);
+
+        Feed getDeletedFeed = feedRepository.findByFeedId(getAddedFeed.getFeedId());
+        assertThat(getDeletedFeed.isActivated()).isFalse();
+
+    }
+}


### PR DESCRIPTION
## 요약
빌딩 피드를 Naver CLOVA Summary로 요약하는 기능을 구현했습니다.

## 변경 사항 설명
특정 시간마다 AI요약 서비스를 호출하여 건물별 피드 요약 정보를 Update하는 로직이 추가되었습니다.
스프링 스케줄러를 사용하였습니다. 

스케줄링에 관한 메서드와 필드 묶음인 ScheduledTasks 클래스를 common패키지에 만들었습니다.
성진님의 채팅방 폭발(?) 기능도 이곳에서 작성하시면 될 것 같습니다.

API의 key와 요약을 위한 buildingId들을 정의한 메타데이터는 드라이브에 올려두었습니다.
buildingId를 메타데이터화 한 이유는 @Scheduled된 메서드에 파라미터를 줄 수 없기 때문입니다.

- [X] findFeedAISummary()
- [X] ScheduledTasks

## 관련 이슈 및 참고 자료
#52 
