### PR TITLE
feat : Winterhana/#37/feed service : FeedService 추가, FeedSubService 추가 중

### DIFF
--- a/src/main/java/com/kube/noon/feed/domain/Feed.java
+++ b/src/main/java/com/kube/noon/feed/domain/Feed.java
@@ -73,6 +73,9 @@ public class Feed {
     @JoinColumn(name = "writer_id", nullable = false)
     private Member writer;
 
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FeedAttachment> attachments;
+
     @Override
     public String toString() {
         return "MemberId : " + writer.getMemberId()

--- a/src/main/java/com/kube/noon/feed/domain/FeedAttachment.java
+++ b/src/main/java/com/kube/noon/feed/domain/FeedAttachment.java
@@ -40,6 +40,6 @@ public class FeedAttachment {
 
     @Override
     public String toString() {
-        return "attachmentId : " + attachmentId + " fileUrl : " + fileUrl + " activated : " + activated;
+        return "attachmentId : " + attachmentId + " / fileUrl : " + fileUrl + " / activated : " + activated + " / FileType : " + fileType;
     }
 }

--- a/src/main/java/com/kube/noon/feed/dto/FeedAttachmentDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedAttachmentDto.java
@@ -2,7 +2,11 @@ package com.kube.noon.feed.dto;
 
 import com.kube.noon.common.FileType;
 import com.kube.noon.feed.domain.Feed;
+import com.kube.noon.feed.domain.FeedAttachment;
 import lombok.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 @NoArgsConstructor
@@ -12,9 +16,33 @@ import lombok.*;
 @ToString
 public class FeedAttachmentDto {
     private int attachmentId;
-    private Feed feed;
+    private int feedId;
     private String fileUrl;
     private FileType fileType;
     private String blurredFileUrl;
     private boolean activated;
+
+    public static FeedAttachmentDto toDto(FeedAttachment feedAttachment) {
+        return FeedAttachmentDto.builder()
+                .attachmentId(feedAttachment.getAttachmentId())
+                .feedId(feedAttachment.getFeed().getFeedId())
+                .fileUrl(feedAttachment.getFileUrl())
+                .fileType(feedAttachment.getFileType())
+                .blurredFileUrl(feedAttachment.getBlurredFileUrl())
+                .build();
+    }
+
+    public static FeedAttachment toEntity(FeedAttachmentDto feedAttachmentDto) {
+        return FeedAttachment.builder()
+                .attachmentId(feedAttachmentDto.getAttachmentId())
+                .feed(Feed.builder().feedId(feedAttachmentDto.getFeedId()).build())
+                .fileUrl(feedAttachmentDto.getFileUrl())
+                .fileType(feedAttachmentDto.getFileType())
+                .blurredFileUrl(feedAttachmentDto.getBlurredFileUrl())
+                .build();
+    }
+
+    public static List<FeedAttachmentDto> toDtoList(List<FeedAttachment> attachments) {
+        return attachments.stream().map(FeedAttachmentDto::toDto).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/kube/noon/feed/dto/FeedDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedDto.java
@@ -1,13 +1,19 @@
 package com.kube.noon.feed.dto;
 
+import com.kube.noon.building.domain.Building;
+import com.kube.noon.building.repository.BuildingProfileRepository;
 import com.kube.noon.common.FeedCategory;
 import com.kube.noon.common.PublicRange;
+import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.feed.domain.FeedComment;
 import com.kube.noon.feed.domain.TagFeed;
+import com.kube.noon.member.domain.Member;
+import com.kube.noon.member.repository.MemberRepository;
 import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 @NoArgsConstructor
@@ -18,16 +24,59 @@ import java.util.List;
 public class FeedDto {
     private int feedId;
     private String writerId;
+    private String writerNickname;
     private int buildingId;
-    private boolean mainActivated;
+    private String buildingName;
     private PublicRange publicRange;
     private String title;
     private String feedText;
     private Long viewCnt;
     private LocalDateTime writtenTime;
     private FeedCategory feedCategory;
-    private boolean modified;
-    private boolean activated;
+    private boolean isModified;
+    private boolean isMainActivated;
     private List<FeedComment> comments;
     private List<TagFeed> tagFeeds;
+
+    public static FeedDto toDto(Feed feed) {
+        return FeedDto.builder()
+                .feedId(feed.getFeedId())
+                .writerId(feed.getWriter().getMemberId())
+                .writerNickname(feed.getWriter().getNickname())
+                .buildingId(feed.getBuilding().getBuildingId())
+                .buildingName(feed.getBuilding().getBuildingName())
+                .publicRange(feed.getPublicRange())
+                .title(feed.getTitle())
+                .feedText(feed.getFeedText())
+                .viewCnt(feed.getViewCnt())
+                .writtenTime(feed.getWrittenTime())
+                .feedCategory(feed.getFeedCategory())
+                .isModified(feed.isModified())
+                .isMainActivated(feed.isMainActivated())
+                .comments(feed.getComments())
+                .tagFeeds(feed.getTagFeeds())
+                .build();
+    }
+
+    public static Feed toEntity(FeedDto feedDto) {
+        return Feed.builder()
+                .feedId(feedDto.getFeedId())
+                .writer(Member.builder().memberId(feedDto.getWriterId()).nickname(feedDto.getWriterNickname()).build())
+                .building(Building.builder().buildingId(feedDto.getBuildingId()).buildingName(feedDto.getBuildingName()).build())
+                .publicRange(feedDto.getPublicRange())
+                .title(feedDto.getTitle())
+                .feedText(feedDto.getFeedText())
+                .viewCnt(feedDto.getViewCnt())
+                .writtenTime(feedDto.getWrittenTime())
+                .feedCategory(feedDto.getFeedCategory())
+                .modified(feedDto.isModified())
+                .mainActivated(feedDto.isMainActivated())
+                .comments(feedDto.getComments())
+                .tagFeeds(feedDto.getTagFeeds())
+                .build();
+    }
+
+    public static List<FeedDto> toDtoList(List<Feed> feeds) {
+        return feeds.stream().map(FeedDto::toDto).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/kube/noon/feed/dto/FeedSummaryDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedSummaryDto.java
@@ -1,0 +1,45 @@
+package com.kube.noon.feed.dto;
+
+import com.kube.noon.feed.domain.Feed;
+import lombok.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class FeedSummaryDto {
+    private int feedId;
+    private String writerId;
+    private String writerNickname;
+    private String title;
+    private String feedText;
+    private int buildingId;
+    private String buildingName;
+    private String feedAttachementURL;
+
+    public static FeedSummaryDto toDto(Feed feed) {
+        return FeedSummaryDto.builder()
+                .feedId(feed.getFeedId())
+                .writerId(feed.getWriter().getMemberId())
+                .writerNickname(feed.getWriter().getNickname())
+                .title(feed.getTitle())
+                .feedText(feed.getFeedText())
+                .buildingId(feed.getBuilding().getBuildingId())
+                .buildingName(feed.getBuilding().getBuildingName())
+                .feedAttachementURL((feed.getAttachments() == null || feed.getAttachments().size() == 0) ? null : feed.getAttachments().get(0).getFileUrl())
+                .build();
+    }
+
+    public static List<FeedSummaryDto> toDtoList(List<Feed> feeds) {
+        if(feeds == null || feeds.isEmpty()) {
+            return null;
+        } else {
+            return feeds.stream().map(FeedSummaryDto::toDto).collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/com/kube/noon/feed/repository/FeedAttachmentRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/FeedAttachmentRepository.java
@@ -1,5 +1,6 @@
 package com.kube.noon.feed.repository;
 
+import com.kube.noon.common.FileType;
 import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.feed.domain.FeedAttachment;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,14 +11,21 @@ public interface FeedAttachmentRepository extends JpaRepository<FeedAttachment, 
     /**
      * 피드의 첨부파일을 가져온다.
      * @param feed
-     * @return
+     * @return List<FeedAttachment>
      */
     List<FeedAttachment> findByFeed(Feed feed);
 
     /**
      * 첨부파일 아이디로 첨부파일을 찾는다.
      * @param attachmentId
-     * @return
+     * @return FeedAttachment
      */
     FeedAttachment findByAttachmentId(int attachmentId);
+
+    /**
+     * 파일 타입으로 첨부파일을 찾는다.
+     * @param fileType
+     * @return List<FeedAttachment>
+     */
+    List<FeedAttachment> findByFileType(FileType fileType);
 }

--- a/src/main/java/com/kube/noon/feed/repository/FeedRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/FeedRepository.java
@@ -46,7 +46,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
      * @param writer 대상 회원을 받는다.
      * @return Feed 회원의 메인 피드를 가져온다.
      */
-    Feed findByWriterAndMainActivatedTrue(Member writer);
+    List<Feed> findByWriterAndMainActivatedTrue(Member writer);
 
     /**
      * 회원이 좋아요를 누른 피드 목록을 가져온다. 단, 활성화가 된 피드만 가져온다.

--- a/src/main/java/com/kube/noon/feed/repository/TagRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/TagRepository.java
@@ -10,18 +10,31 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
-    /**
-     * 각 피드에 붙어있는 피드의 내용을 가져온다.
-     * @param feed
-     * @return
-     */
-    @Query("""
-        SELECT t
-        FROM TagFeed f
-                 INNER JOIN Tag t ON f.tag.tagId = t.tagId
-        WHERE f.feed.feedId = :#{#feed.feedId}
-        """)
-    List<Tag> getTagByFeedId(@Param("feed") Feed feed);
+//    /**
+//     * 각 피드에 붙어있는 피드의 내용을 가져온다.
+//     * @param feed
+//     * @return
+//     */
+//    @Query("""
+//        SELECT t
+//        FROM TagFeed f
+//                 INNER JOIN Tag t ON f.tag.tagId = t.tagId
+//        WHERE f.feed.feedId = :#{#feed.feedId}
+//        """)
+//    List<Tag> getTagByFeedId(@Param("feed") Feed feed);
+
+     /**
+      * 각 피드에 붙어있는 피드의 내용을 가져온다.
+      * @param feed
+      * @return
+      */
+     @Query("""
+         SELECT t
+         FROM Tag t
+                  INNER JOIN TagFeed f ON t.tagId = f.tag.tagId
+         WHERE f.feed.feedId = :#{#feed.feedId}
+         """)
+     List<Tag> getTagByFeedId(@Param("feed") Feed feed);
 
     /**
      * 태그 택스트로 태그를 찾는다.

--- a/src/main/java/com/kube/noon/feed/repository/mybatis/TagMyBatisRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/mybatis/TagMyBatisRepository.java
@@ -12,5 +12,6 @@ public interface TagMyBatisRepository {
      * @param feedId
      * @return
      */
+    @Deprecated
     List<TagDto> getTagByFeedId(int feedId);
 }

--- a/src/main/java/com/kube/noon/feed/service/FeedService.java
+++ b/src/main/java/com/kube/noon/feed/service/FeedService.java
@@ -1,57 +1,35 @@
 package com.kube.noon.feed.service;
 
-import com.kube.noon.building.domain.Building;
 import com.kube.noon.feed.dto.FeedDto;
-import com.kube.noon.feed.domain.Feed;
-import com.kube.noon.member.domain.Member;
+import com.kube.noon.feed.dto.FeedSummaryDto;
+import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.List;
 
+@Service
 public interface FeedService {
-    public List<Feed> getFeedList() throws IOException;
+    List<FeedSummaryDto> getFeedListByMember(String memberId);
 
-    public default Feed dtoToEntity(FeedDto feedDto) {
-        // 임시로 생성 후 대입
-        Member writer = new Member();
-        writer.setMemberId(feedDto.getWriterId());
+    List<FeedSummaryDto> getFeedListByBuilding(int buildingId);
 
-        Feed feed = Feed.builder()
-                .feedId(feedDto.getFeedId())
-                .title(feedDto.getTitle())
-                .mainActivated(feedDto.isMainActivated())
-                .publicRange(feedDto.getPublicRange())
-                .feedText(feedDto.getFeedText())
-                .viewCnt(feedDto.getViewCnt())
-                .feedCategory(feedDto.getFeedCategory())
-                .modified(feedDto.isModified())
-                .activated(feedDto.isActivated())
-                .comments(feedDto.getComments())
-                .tagFeeds(feedDto.getTagFeeds())
-                .building(Building.builder().buildingId(feedDto.getBuildingId()).build())
-                .writer(writer)
-                .build();
+    List<FeedSummaryDto> getFeedListByMemberLike(String memberId);
 
-        return feed;
-    }
+    List<FeedSummaryDto> getFeedListByMemberBookmark(String memberId);
 
-    public default FeedDto entityToDto(Feed feed) {
-        FeedDto feedDto = FeedDto.builder()
-                .feedId(feed.getFeedId())
-                .writerId(feed.getWriter().getMemberId())
-                .buildingId(feed.getBuilding().getBuildingId())
-                .mainActivated(feed.isMainActivated())
-                .publicRange(feed.getPublicRange())
-                .title(feed.getTitle())
-                .feedText(feed.getFeedText())
-                .viewCnt(feed.getViewCnt())
-                .writtenTime(feed.getWrittenTime())
-                .feedCategory(feed.getFeedCategory())
-                .modified(feed.isModified())
-                .activated(feed.isActivated())
-                .comments(feed.getComments())
-                .tagFeeds(feed.getTagFeeds())
-                .build();
-        return feedDto;
-    }
+    List<FeedSummaryDto> getFeedListByBuildingSubscription(String memberId);
+
+    int addFeed(FeedDto feedDto);
+
+    int updateFeed(FeedDto feedSummaryDto);
+
+    int deleteFeed(FeedDto feedSummaryDto);
+
+    FeedDto getFeedById(int feedId);
+
+    int setPublicRage(FeedDto feedDto);
+
+    int setMainFeed(FeedDto feedDto);
+
+    List<FeedSummaryDto> searchFeedList(String keyword);
 }

--- a/src/main/java/com/kube/noon/feed/service/FeedSubService.java
+++ b/src/main/java/com/kube/noon/feed/service/FeedSubService.java
@@ -1,0 +1,12 @@
+package com.kube.noon.feed.service;
+
+import com.kube.noon.common.FileType;
+import com.kube.noon.feed.dto.FeedAttachmentDto;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public interface FeedSubService {
+    public List<FeedAttachmentDto> getFeedAttachementListByFileType(FileType fileType);
+}

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
@@ -1,11 +1,18 @@
 package com.kube.noon.feed.service.impl;
 
+import com.kube.noon.building.domain.Building;
 import com.kube.noon.feed.domain.Feed;
+import com.kube.noon.feed.dto.FeedDto;
+import com.kube.noon.feed.dto.FeedSummaryDto;
 import com.kube.noon.feed.repository.FeedRepository;
 import com.kube.noon.feed.service.FeedService;
+import com.kube.noon.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.util.List;
@@ -14,10 +21,141 @@ import java.util.List;
 @Log4j2
 @RequiredArgsConstructor
 public class FeedServiceImpl implements FeedService {
+
+    @Autowired
     private final FeedRepository feedRepository;
 
     @Override
-    public List<Feed> getFeedList() throws IOException {
-        return feedRepository.findAll();
+    public List<FeedSummaryDto> getFeedListByMember(String memberId) {
+        List<Feed> entities = feedRepository.findByWriterAndActivatedTrue(
+                Member.builder()
+                        .memberId(memberId)
+                        .build()
+        );
+
+        List<FeedSummaryDto> feedListByMember = FeedSummaryDto.toDtoList(entities);
+
+        return feedListByMember;
+    }
+
+    @Override
+    public List<FeedSummaryDto> getFeedListByBuilding(int buildingId) {
+        List<Feed> entities = feedRepository.findByBuildingAndActivatedTrue(
+                Building.builder()
+                        .buildingId(buildingId)
+                        .build()
+        );
+
+        List<FeedSummaryDto> feedListByBuilding = FeedSummaryDto.toDtoList(entities);
+
+        return feedListByBuilding;
+    }
+
+    @Override
+    public List<FeedSummaryDto> getFeedListByMemberLike(String memberId) {
+        List<Feed> entites = feedRepository.findByMemberLikeFeed(
+                Member.builder()
+                        .memberId(memberId)
+                        .build()
+        );
+
+        List<FeedSummaryDto> feedListByMemberLike = FeedSummaryDto.toDtoList(entites);
+
+        return feedListByMemberLike;
+    }
+
+    @Override
+    public List<FeedSummaryDto> getFeedListByMemberBookmark(String memberId) {
+        List<Feed> entites = feedRepository.findByMemberBookmarkFeed(
+                Member.builder()
+                        .memberId(memberId)
+                        .build()
+        );
+
+        List<FeedSummaryDto> feedListByMemberBookmark = FeedSummaryDto.toDtoList(entites);
+
+        return feedListByMemberBookmark;
+    }
+
+    @Override
+    public List<FeedSummaryDto> getFeedListByBuildingSubscription(String memberId) {
+        List<Feed> entites = feedRepository.findByMemberBuildingSubscription(
+                Member.builder()
+                        .memberId(memberId)
+                        .build()
+        );
+
+        List<FeedSummaryDto> feedListByBuildingSubscription = FeedSummaryDto.toDtoList(entites);
+
+        return feedListByBuildingSubscription;
+    }
+
+    @Override
+    public int addFeed(FeedDto feedDto) {
+        Feed addFeed = FeedDto.toEntity(feedDto);
+        return feedRepository.save(addFeed).getFeedId();
+    }
+
+    @Override
+    public int updateFeed(FeedDto feedDto) {
+        Feed updateFeed = feedRepository.findByFeedId(feedDto.getFeedId());
+
+        updateFeed.setTitle(feedDto.getTitle());
+        updateFeed.setFeedText(feedDto.getFeedText());
+        updateFeed.setModified(true);
+        updateFeed.setFeedCategory(feedDto.getFeedCategory());
+        return feedRepository.save(updateFeed).getFeedId();
+    }
+
+    @Override
+    public int deleteFeed(FeedDto feedDto) {
+        Feed deleteFeed = feedRepository.findByFeedId(feedDto.getFeedId());
+
+        deleteFeed.setActivated(false);
+        return feedRepository.save(deleteFeed).getFeedId();
+    }
+
+    @Override
+    public FeedDto getFeedById(int feedId) {
+        Feed getFeed = feedRepository.findByFeedId(feedId);
+        return FeedDto.toDto(getFeed);
+    }
+
+    @Override
+    public int setPublicRage(FeedDto feedDto) {
+        Feed setPublicRangeFeed = feedRepository.findByFeedId(feedDto.getFeedId());
+
+        setPublicRangeFeed.setPublicRange(feedDto.getPublicRange());
+        return feedRepository.save(setPublicRangeFeed).getFeedId();
+    }
+
+    @Override
+    public int setMainFeed(FeedDto feedDto) {
+
+        // 1. 등록된 대표 피드 취소
+        List<Feed> mainFeeds = feedRepository.findByWriterAndMainActivatedTrue(Member.builder().memberId(feedDto.getWriterId()).build());
+        if(mainFeeds != null) {
+            mainFeeds.stream().forEach(s -> {
+                s.setMainActivated(false);
+                feedRepository.save(s);
+            });
+        }
+
+        // 2. 새로운 대표 피드 등록
+        Feed setMainFeed = feedRepository.findByFeedId(feedDto.getFeedId());
+        setMainFeed.setMainActivated(true);
+        return feedRepository.save(setMainFeed).getFeedId();
+    }
+
+    @Override
+    public List<FeedSummaryDto> searchFeedList(String keyword) {
+        List<Feed> searchFeedTextList = feedRepository.findByFeedTextContainingIgnoreCase(keyword);
+        List<Feed> searchFeedTitleList = feedRepository.findByTitleContainingIgnoreCase(keyword);
+
+        searchFeedTextList.addAll(searchFeedTitleList);
+
+        List<FeedSummaryDto> searchFeedList = FeedSummaryDto.toDtoList(searchFeedTextList);
+
+        return searchFeedList;
     }
 }

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
@@ -9,12 +9,8 @@ import com.kube.noon.feed.service.FeedService;
 import com.kube.noon.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
 import java.util.List;
 
 @Service
@@ -22,7 +18,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FeedServiceImpl implements FeedService {
 
-    @Autowired
     private final FeedRepository feedRepository;
 
     @Override

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
@@ -1,0 +1,32 @@
+package com.kube.noon.feed.service.impl;
+
+import com.kube.noon.common.FileType;
+import com.kube.noon.feed.domain.FeedAttachment;
+import com.kube.noon.feed.dto.FeedAttachmentDto;
+import com.kube.noon.feed.repository.*;
+import com.kube.noon.feed.service.FeedSubService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class FeedSubServiceImpl implements FeedSubService {
+
+    private final FeedRepository feedRepository;
+    private final FeedAttachmentRepository feedAttachmentRepository;
+    private final FeedCommentRepository feedCommentRepository;
+    private final TagFeedRepository tagFeedRepository;
+    private final TagRepository tagRepository;
+
+
+    @Override
+    public List<FeedAttachmentDto> getFeedAttachementListByFileType(FileType fileType) {
+        List<FeedAttachment> feedAttachments = feedAttachmentRepository.findByFileType(fileType);
+
+        return FeedAttachmentDto.toDtoList(feedAttachments);
+    }
+}

--- a/src/test/java/com/kube/noon/feed/repository/TestFeedAttachmentRepository.java
+++ b/src/test/java/com/kube/noon/feed/repository/TestFeedAttachmentRepository.java
@@ -75,4 +75,19 @@ public class TestFeedAttachmentRepository {
         assertThat(feedAttachmentRepository.save(feedAttachment)).isNotNull();
         log.info(feedAttachment);
     }
+
+    /**
+     * 첨부파일의 종류별로 목록을 가져온다.
+     * 이 테스트에서는 FileType.PHOTO 를 기준으로 가져온다.
+     */
+    @Transactional
+    @Test
+    public void getFeedAttachmentByFileType() {
+        List<FeedAttachment> attachments = feedAttachmentRepository.findByFileType(FileType.PHOTO);
+
+        assertThat(attachments.size()).isGreaterThan(0);
+        for (FeedAttachment attachment : attachments) {
+            log.info(attachment);
+        }
+    }
 }

--- a/src/test/java/com/kube/noon/feed/repository/TestFeedRepository.java
+++ b/src/test/java/com/kube/noon/feed/repository/TestFeedRepository.java
@@ -246,13 +246,20 @@ public class TestFeedRepository {
         Member member = new Member();
         member.setMemberId("member_1");
 
-        Feed mainFeed = feedRepository.findByWriterAndMainActivatedTrue(member); // 1.
-        mainFeed.setMainActivated(false); // 2.
-        feedRepository.save(mainFeed);
+        // 메인 피드가 다중으로 설정되어 있을 수 있기 때문에 List로 받음
+        List<Feed> mainFeeds = feedRepository.findByWriterAndMainActivatedTrue(member); // 1.
+
+        assertThat(mainFeeds.size()).isGreaterThan(0);
+
+        mainFeeds.stream().forEach(s -> {
+            s.setMainActivated(false);
+            feedRepository.save(s);
+        }); // 2
 
         Feed setMainFeed = feedRepository.findByFeedId(10006); // 3.
         setMainFeed.setMainActivated(true); // 4.
         feedRepository.save(setMainFeed);
+
 
         assertThat(feedRepository.findByFeedId(10006).isMainActivated()).isEqualTo(true);
     }

--- a/src/test/java/com/kube/noon/feed/repository/TestTagFeedRepository.java
+++ b/src/test/java/com/kube/noon/feed/repository/TestTagFeedRepository.java
@@ -1,6 +1,5 @@
 package com.kube.noon.feed.repository;
 
-import com.kube.noon.feed.dto.TagDto;
 import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.feed.domain.Tag;
 import com.kube.noon.feed.domain.TagFeed;

--- a/src/test/java/com/kube/noon/feed/service/TestFeedServiceImpl.java
+++ b/src/test/java/com/kube/noon/feed/service/TestFeedServiceImpl.java
@@ -1,0 +1,199 @@
+package com.kube.noon.feed.service;
+
+import com.kube.noon.building.domain.Building;
+import com.kube.noon.common.FeedCategory;
+import com.kube.noon.common.PublicRange;
+import com.kube.noon.feed.domain.Feed;
+import com.kube.noon.feed.dto.FeedDto;
+import com.kube.noon.feed.dto.FeedSummaryDto;
+import com.kube.noon.feed.repository.FeedRepository;
+import com.kube.noon.feed.service.impl.FeedServiceImpl;
+import com.kube.noon.member.domain.Member;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Log4j2
+@SpringBootTest
+@ActiveProfiles("winterhana")
+public class TestFeedServiceImpl {
+
+    @Autowired
+    private FeedServiceImpl feedServiceImpl;
+
+    @Autowired
+    private FeedRepository feedRepository;
+
+    /**
+     * 피드 목록을 가져오는 테스트를 한다.
+     * memberId = "member_1", buildingId = 10000을 기준으로 한다.
+     */
+    @Transactional
+    @Test
+    public void getListTest() {
+        List<FeedSummaryDto> feedListByMember = feedServiceImpl.getFeedListByMember("member_1");
+        assertThat(feedListByMember).isNotNull();
+        assertThat(feedListByMember.size()).isGreaterThan(0);
+        for (FeedSummaryDto feedSummaryDto : feedListByMember) {
+            log.info(feedSummaryDto);
+        }
+
+        List<FeedSummaryDto> feedListByBuilding = feedServiceImpl.getFeedListByBuilding(10000);
+        assertThat(feedListByBuilding).isNotNull();
+        assertThat(feedListByBuilding.size()).isGreaterThan(0);
+        for (FeedSummaryDto feedSummaryDto : feedListByBuilding) {
+            log.info(feedSummaryDto);
+        }
+
+        List<FeedSummaryDto> feedListByMemberLike = feedServiceImpl.getFeedListByMemberLike("member_1");
+        assertThat(feedListByMemberLike).isNotNull();
+        assertThat(feedListByMemberLike.size()).isGreaterThan(0);
+        for (FeedSummaryDto feedSummaryDto : feedListByMemberLike) {
+            log.info(feedSummaryDto);
+        }
+
+        List<FeedSummaryDto> feedListByMemberBookmark = feedServiceImpl.getFeedListByMemberBookmark("member_1");
+        assertThat(feedListByMemberBookmark).isNotNull();
+        assertThat(feedListByMemberBookmark.size()).isGreaterThan(0);
+        for (FeedSummaryDto feedSummaryDto : feedListByMemberBookmark) {
+            log.info(feedSummaryDto);
+        }
+
+        List<FeedSummaryDto> feedListByBuildingSubscription = feedServiceImpl.getFeedListByBuildingSubscription("member_1");
+        assertThat(feedListByBuildingSubscription).isNotNull();
+        assertThat(feedListByBuildingSubscription.size()).isGreaterThan(0);
+        for (FeedSummaryDto feedSummaryDto : feedListByBuildingSubscription) {
+            log.info(feedSummaryDto);
+        }
+    }
+
+    /**
+     * 피드를 추가한다.
+     * 글을 하나도 적지 않은 건물 내에서 긍을 처음 작성하는 유저 대상으로 테스트한다.
+     * building_id = 10015, writer_id = 'member_15'
+     */
+    @Transactional
+    @Test
+    public void addFeedTest() {
+        FeedDto feedDto = FeedDto.builder()
+                .writerId("member_15")
+                .buildingId(10015)
+                .isMainActivated(false)
+                .publicRange(PublicRange.PUBLIC)
+                .title("WinterHana Test")
+                .feedText("테스트 중입니다.")
+                .viewCnt(9999L)
+                .writtenTime(LocalDateTime.now())
+                .feedCategory(FeedCategory.GENERAL)
+                .isModified(false)
+                .build();
+
+        int feedId = feedServiceImpl.addFeed(feedDto);
+
+        FeedDto getFeedDto = feedServiceImpl.getFeedById(feedId);
+
+        assertThat(getFeedDto).isNotNull();
+        assertThat(getFeedDto.getWriterId()).isEqualTo("member_15");
+        assertThat(getFeedDto.getBuildingId()).isEqualTo(10015);
+        assertThat(getFeedDto.getTitle()).isEqualTo("WinterHana Test");
+    }
+
+    /**
+     * feed_id = 10000인 피드를 수정한다. 이때, 피으의 Text를 수정하고 확인한다.
+     */
+    @Transactional
+    @Test
+    public void updateFeedTest() {
+        FeedDto updateFeedDto = feedServiceImpl.getFeedById(10000);
+        updateFeedDto.setFeedText("수정 테스트 중입니다.");
+
+        int feedId = feedServiceImpl.updateFeed(updateFeedDto);
+
+        FeedDto getFeedDto = feedServiceImpl.getFeedById(feedId);
+
+        assertThat(getFeedDto).isNotNull();
+        assertThat(getFeedDto.getWriterId()).isEqualTo("member_1");
+        assertThat(getFeedDto.getBuildingId()).isEqualTo(10001);
+        assertThat(getFeedDto.getTitle()).isEqualTo("Title_1");
+        assertThat(getFeedDto.getFeedText()).isEqualTo("수정 테스트 중입니다.");
+    }
+
+    /**
+     * feed_id = 10000인 피드를 삭제, 즉 비공개한다.
+     */
+    @Transactional
+    @Test
+    public void deleteFeedTest() {
+        FeedDto deleteFeed = feedServiceImpl.getFeedById(10000);
+
+        int feedId = feedServiceImpl.deleteFeed(deleteFeed);
+
+        // 지워진 피드는 Repository 내에서 확인 가능하다.
+        Feed getFeed = feedRepository.findByFeedId(feedId);
+
+        assertThat(getFeed).isNotNull();
+        assertThat(getFeed.isActivated()).isFalse();
+    }
+
+    /**
+     * 피드의 공개 범위를 수정한다.
+     * feed_id = 10010을 기준으로 PRIVATE로 변경한다.
+     */
+    @Transactional
+    @Test
+    public void setPublicRangeTest() {
+        FeedDto setPublicRangeFeedDto = FeedDto.builder()
+                .feedId(10010)
+                .publicRange(PublicRange.PRIVATE)
+                .build();
+
+        int feedId = feedServiceImpl.setPublicRage(setPublicRangeFeedDto);
+
+        FeedDto getFeedDto = feedServiceImpl.getFeedById(feedId);
+
+        assertThat(getFeedDto.getFeedId()).isEqualTo(10010);
+        assertThat(getFeedDto.getPublicRange()).isEqualTo(PublicRange.PRIVATE);
+    }
+
+    /**
+     * 피드의 메인 피드를 수정한다.
+     * writer_id = "member_1"의 메인 피드를 feed_id = 10008로 수정한다.
+     */
+    @Transactional
+    @Test
+    public void setMainFeedTest() {
+        FeedDto setMainFeedDto = FeedDto.builder()
+                .feedId(10008)
+                .writerId("member_1")
+                .build();
+
+        int feedId = feedServiceImpl.setMainFeed(setMainFeedDto);
+
+        FeedDto getFeedDto = feedServiceImpl.getFeedById(feedId);
+
+        assertThat(getFeedDto).isNotNull();
+        assertThat(getFeedDto.isMainActivated()).isTrue();
+    }
+
+    /**
+     * 피드의 제목이나 내용을 기준으로 검색한다.
+     */
+    public void searchFeedListTest() {
+        String keyword = "Title_1";
+
+        List<FeedSummaryDto> searchFeedList = feedServiceImpl.searchFeedList(keyword);
+
+        assertThat(searchFeedList.size()).isGreaterThan(0);
+        for(FeedSummaryDto f : searchFeedList) {
+            log.info(f.toString());
+        }
+    }
+}

--- a/src/test/java/com/kube/noon/feed/service/TestFeedSubServiceImpl.java
+++ b/src/test/java/com/kube/noon/feed/service/TestFeedSubServiceImpl.java
@@ -1,0 +1,45 @@
+package com.kube.noon.feed.service;
+
+import com.kube.noon.common.FileType;
+import com.kube.noon.feed.dto.FeedAttachmentDto;
+import com.kube.noon.feed.repository.FeedRepository;
+import com.kube.noon.feed.service.impl.FeedServiceImpl;
+import com.kube.noon.feed.service.impl.FeedSubServiceImpl;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Log4j2
+@SpringBootTest
+@ActiveProfiles("winterhana")
+public class TestFeedSubServiceImpl {
+    @Autowired
+    private FeedServiceImpl feedServiceImpl;
+
+    @Autowired
+    private FeedSubServiceImpl feedSubServiceImpl;
+
+    /**
+     * 원하는 타입의 첨부파일을 가져온다
+     * 여기서는 FileType.PHOTO를 기준으로 한다.
+     */
+    @Transactional
+    @Test
+    public void getFeedAttachementListByFileTypeTest() {
+        List<FeedAttachmentDto> feedAttachmentDtoList = feedSubServiceImpl.getFeedAttachementListByFileType(FileType.PHOTO);
+
+        assertThat(feedAttachmentDtoList).isNotNull();
+        assertThat(feedAttachmentDtoList).isNotEmpty();
+        assertThat(feedAttachmentDtoList.size()).isGreaterThan(0);
+        for (FeedAttachmentDto feedAttachmentDto : feedAttachmentDtoList) {
+            log.info(feedAttachmentDto);
+        }
+    }
+}


### PR DESCRIPTION
## 요약
FeedService 를 구현하고 FeedSubService를 구현 중입니다.

## 변경 사항 설명
- `FeedService` : 피드의 목록을 가져오거나 피드 자체의 CRUD를 모아둔 Service입니다.
- `FeedSubService` : 피드 외 연관이 있는 테이블에 대한 CRUD를 모아둔 Service입니다.
- Service 기능에 따른 리스트는 issue : #37 에서 확인 가능합니다.
- 요구사항에 따라 FeedSubService에 우선적으로 구현할 것을 구현하고 PR를 보냅니다. 추후에 완성하고 PR를 다시 보낼 예정입니다.

## 관련 이슈 및 참고 자료
issue : #37 
