### PR TITLE
hotfix: ValidationAspect에서 발생하는 NullPointerException 해결

### DIFF
--- a/src/main/java/com/kube/noon/common/validator/IllegalServiceCallException.java
+++ b/src/main/java/com/kube/noon/common/validator/IllegalServiceCallException.java
@@ -4,10 +4,18 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * 만약 검증 메소드에서 예외를 던지고자 한다면 이 예외를 던지면 된다.
- * 어떤 파라미터가 어떻게 문제인지를 생성자의 Problems 객체로 전달할 수 있다.
+ * <p>만약 검증 메소드에서 예외를 던지고자 한다면 이 예외를 던지면 된다.
+ * <p>어떤 파라미터가 어떻게 문제인지를 생성자의 Problems 객체로 전달할 수 있다.
+ * <p>예를 들어, addMember(String memberId, String password) 라는 메소드가 있다고 하자.
+ * <p>memberId에 문제가 있는 경우,
+ * <p>Problems problems = new Problems();<br>
+ * problems.put("memberId", "유효하지 않은 memberId");<br>
+ * throw new IllegalServiceCallException(problems);<br>
+ * <p>이와 같이 IllegalServiceCallException을 던질 수 있다.
  *
  * @author PGD
+ * @see Problems
+ * @see Validator
  */
 public class IllegalServiceCallException extends IllegalArgumentException {
     private final Problems problems;

--- a/src/main/java/com/kube/noon/common/validator/Problems.java
+++ b/src/main/java/com/kube/noon/common/validator/Problems.java
@@ -6,13 +6,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * 검증 로직에서 각 문제가 있는 부분을 저장하는 객체
- * IllegalServiceCallException에 저장된다.
- * Key에는 문제가 있는 Parameter의 이름이 담길 수 있고
+ * <p>검증 로직에서 각 문제가 있는 부분을 저장하는 객체
+ * <p>IllegalServiceCallException에 저장된다.
+ * <p>Key에는 문제가 있는 Parameter의 이름이 담길 수 있고
  * Value에는 아무 객체가 올 수 있으나 보통 String 객체 (검증 실패 메시지)가 담긴다.
  *
  * @author PGD
  * @see IllegalServiceCallException
+ * @see Validator
  */
 @NoArgsConstructor
 public class Problems extends HashMap<String, Object> {

--- a/src/main/java/com/kube/noon/common/validator/ValidationAspect.java
+++ b/src/main/java/com/kube/noon/common/validator/ValidationAspect.java
@@ -1,5 +1,6 @@
 package com.kube.noon.common.validator;
 
+import com.kube.noon.notification.service.validator.NotificationServiceValidator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -7,12 +8,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.aop.framework.AopProxyUtils;
+import org.springframework.aop.support.AopUtils;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.event.EventListener;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,7 +42,9 @@ public class ValidationAspect {
         this.context.getBeansWithAnnotation(Validator.class)
                 .values()
                 .forEach((bean) -> {
-                    Class<?> cls = bean.getClass().getAnnotation(Validator.class).targetClass();
+                    Class<?> cls = AopProxyUtils.ultimateTargetClass(bean)
+                            .getAnnotation(Validator.class)
+                            .targetClass();
                     Method[] publicMethods = bean.getClass().getMethods();
                     Map<String, Method> methodMap = new HashMap<>();
                     for (Method method : publicMethods) {

--- a/src/main/java/com/kube/noon/common/validator/Validator.java
+++ b/src/main/java/com/kube/noon/common/validator/Validator.java
@@ -8,13 +8,24 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * 검증을 담당하는 클래스에 이 어노테이션을 붙이면 된다.
- * 이 어노테이션이 붙는 검증 클래스에 검증 대상 클래스의 메소드 이름과 Parameter가 동일해야 한다.
- * 이 어노테이션이 붙는 검증 클래스의 메소드들은 boolean 타입을 반환함으로써 검증 대상 메소드를 실행시킬지
- * 실행시키지 않을지 결정할 수 있다.
- * 그외에 IllegalServiceCallException을 선언할 수도 있다.
+ * <p>검증을 담당하는 클래스에 이 어노테이션을 붙이면 된다.</p>
+ * <p>이 어노테이션이 붙는 검증 클래스에 검증 대상 클래스의 메소드 이름과 Parameter가 동일해야 한다.</p>
+ * <p>사용법은 검증 메소드의 리턴 타입에 따라 세 가지로 나뉜다.</p><br>
+ * 1. 리턴 타입이 void일 경우<br>
+ * <p>문제가 있으면 IllegalServiceCallException을 던진다.</p><br>
+ * 2. 리턴 타입이 boolean일 경우<br>
+ * <p>true를 반환하면 그대로 진행되고, false를 반환하면 더이상 진행되지 않는다.<br>
+ * 이 경우에도 IllegalServiceCallException을 던짐으로써 대상 서비스 메소드를 실행시키지 않을 수 있다.<br></p><br>
+ * 3. 리턴 타입이 Problems 객체일 경우<br>
+ * <p>어떤 파라미터에 어떤 문제가 있는지 Problems 객체에 담아서 이를 반환할 수 있다.<br>
+ * Problems 객체에 요소가 들어 있을 경우 (i.e., Problems.size() > 0)<br>
+ * 대상 서비스 메소드가 진행되지 않는다.<br>
+ * Problems 객체는 IllegalServiceCallException의 생성자 argument로도 전달할 수 있다.<br></p>
  *
  * @author PGD
+ * @see ValidationAspect
+ * @see Problems
+ * @see IllegalServiceCallException
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/src/test/java/com/kube/noon/notification/service/TestNotificationServiceImpl.java
+++ b/src/test/java/com/kube/noon/notification/service/TestNotificationServiceImpl.java
@@ -85,16 +85,7 @@ class TestNotificationServiceImpl {
     void getNotification_zeroSize() {
         getAndAddSampleReceiver();
 
-        NotificationDto notificationDto = new NotificationDto();
-        notificationDto.setReceiverId("sample-receiver");
-        notificationDto.setNotificationType(NotificationType.COMMENT);
-        notificationDto.setNotificationText("sample-text");
-
-        System.out.println(notificationDto);
-
-        this.notificationService.sendNotification(notificationDto);
-
-        List<NotificationDto> notificationList = this.notificationService.getNotificationList("not-exists");
+        List<NotificationDto> notificationList = this.notificationService.getNotificationList("sample-receiver");
 
         log.info("notificationList={}", notificationList);
 


### PR DESCRIPTION
## 요약
```ValidationAspect```에서 발생하는 ```NullPointerException```을 해결했다.

## 변경 사항 설명
- ```AopProxyUtils.ultimateTargetClass()``` 메소드를 사용해 오리지널 클래스를 가져와 거기에 있는 ```@Validator``` 정보를 가져옴

## 관련 이슈 및 참고 자료
Issue: #64
