### PR TITLE
feat : Green Eye 유해사진 필터링 구현 feat

### DIFF
--- a/src/main/java/com/kube/noon/customersupport/repository/AttachmentFilteringRepository.java
+++ b/src/main/java/com/kube/noon/customersupport/repository/AttachmentFilteringRepository.java
@@ -1,5 +1,9 @@
 package com.kube.noon.customersupport.repository;
 
+import com.kube.noon.feed.domain.FeedAttachment;
+import java.util.List;
+
 public interface AttachmentFilteringRepository {
     public String addBluredFile(String fileUrl);
+    public List<FeedAttachment> findBadImageListByAI(List<FeedAttachment> feedAttachmentList);
 }

--- a/src/main/java/com/kube/noon/customersupport/service/CustomerSupportService.java
+++ b/src/main/java/com/kube/noon/customersupport/service/CustomerSupportService.java
@@ -14,4 +14,7 @@ public interface CustomerSupportService {
     ReportProcessingDto updateReport(ReportProcessingDto reportProcessingDto, String unlockDuration);
 
     FeedAttachmentDto addBluredImage(FeedAttachmentDto attachmentDto) throws IOException;
+
+    List<FeedAttachmentDto> getFilteredListByAI();
+
 }

--- a/src/main/java/com/kube/noon/customersupport/service/CustomerSupportServiceImpl.java
+++ b/src/main/java/com/kube/noon/customersupport/service/CustomerSupportServiceImpl.java
@@ -1,5 +1,6 @@
 package com.kube.noon.customersupport.service;
 
+import com.kube.noon.common.FileType;
 import com.kube.noon.common.ObjectStorageAWS3S;
 import com.kube.noon.customersupport.domain.Report;
 import com.kube.noon.customersupport.dto.report.ReportDto;
@@ -7,6 +8,7 @@ import com.kube.noon.customersupport.dto.report.ReportProcessingDto;
 import com.kube.noon.customersupport.enums.UnlockDuration;
 import com.kube.noon.customersupport.repository.AttachmentFilteringRepository;
 import com.kube.noon.customersupport.repository.ReportRepository;
+import com.kube.noon.feed.domain.FeedAttachment;
 import com.kube.noon.feed.dto.FeedAttachmentDto;
 import com.kube.noon.feed.repository.FeedAttachmentRepository;
 import com.kube.noon.member.domain.Member;
@@ -152,6 +154,18 @@ public class CustomerSupportServiceImpl implements CustomerSupportService{
         feedAttachmentRepository.save(FeedAttachmentDto.toEntity(attachmentDto));
 
         return attachmentDto;
+    }
+
+    @Override
+    public List<FeedAttachmentDto> getFilteredListByAI() {
+
+        List<FeedAttachment> feedAttachmentList = feedAttachmentRepository.findByFileType(FileType.PHOTO);
+
+        List<FeedAttachmentDto> filteredList = attachmentFilteringRepository.findBadImageListByAI(feedAttachmentList).stream()
+                .map(FeedAttachmentDto::toDto)
+                .collect(Collectors.toList());
+
+        return filteredList;
     }
 
 

--- a/src/test/java/com/kube/noon/customersupport/service/TestCustomerSupportService.java
+++ b/src/test/java/com/kube/noon/customersupport/service/TestCustomerSupportService.java
@@ -4,6 +4,7 @@ import com.kube.noon.customersupport.domain.Report;
 import com.kube.noon.customersupport.dto.report.ReportDto;
 import com.kube.noon.customersupport.dto.report.ReportProcessingDto;
 import com.kube.noon.customersupport.enums.UnlockDuration;
+import com.kube.noon.customersupport.repository.AttachmentFilteringRepositoryImpl;
 import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.feed.domain.FeedAttachment;
 import com.kube.noon.feed.dto.FeedAttachmentDto;
@@ -36,7 +37,6 @@ public class TestCustomerSupportService {
 
     @Autowired
     private MemberService memberService;
-
 
 
 
@@ -120,5 +120,11 @@ public class TestCustomerSupportService {
         }
 
         
+    }
+
+    @Test
+    void getFilteredListByAI(){
+        List<FeedAttachmentDto> filteredList = customerSupportService.getFilteredListByAI();
+        log.info("유해성 1차 필터링된 첨부파일={}",filteredList);
     }
 }


### PR DESCRIPTION
## 요약
#58 의 유해사진 필터링 전에 NCloud Green Eye를 이용해 1차 필터링하는 기능을 구현했습니다.

## 변경 사항 설명
임의로 5개의 첨부파일을 두고, file_url을 Object Storage의 url로 Insert하여 테스트했습니다.
- [X]  getFilteredListByGreenEye
- [X]  FindFilteredListByGreenEye

## 관련 이슈 및 참고 자료
#58 
[CLOVA GreenEye API 가이드](https://api.ncloud-docs.com/docs/ai-application-service-greeneye)