### PR TITLE
feat: Chatbot 구현

### DIFF
--- a/src/main/java/com/kube/noon/customersupport/service/ChatbotService.java
+++ b/src/main/java/com/kube/noon/customersupport/service/ChatbotService.java
@@ -1,0 +1,8 @@
+package com.kube.noon.customersupport.service;
+
+import com.kube.noon.customersupport.domain.ChatbotConversation;
+
+public interface ChatbotService {
+
+    public ChatbotConversation ask(String question);
+}

--- a/src/main/java/com/kube/noon/customersupport/service/ChatbotServiceImpl.java
+++ b/src/main/java/com/kube/noon/customersupport/service/ChatbotServiceImpl.java
@@ -1,0 +1,63 @@
+package com.kube.noon.customersupport.service;
+
+import com.kube.noon.customersupport.domain.ChatbotConversation;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.RequestEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+@Service
+public class ChatbotServiceImpl implements ChatbotService {
+    private static final String UNIQUE_USER_ID = "awvoawhifhoizxihovihodsdasd";
+
+    private final RestTemplate restTemplate;
+    private final String chatbotUrl;
+
+    public ChatbotServiceImpl(@Value("${chatbot.naver.url}") String chatbotUrl) {
+        this.chatbotUrl = chatbotUrl;
+        this.restTemplate = new RestTemplate();
+    }
+
+    @Override
+    public ChatbotConversation ask(String question) {
+        JSONObject body = new JSONObject();
+        body.put("userId", UNIQUE_USER_ID);
+        body.put("timestamp", LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd")));
+        JSONArray content = new JSONArray();
+        JSONObject contentElement = new JSONObject();
+        contentElement.put("type", "text");
+        JSONObject contentData = new JSONObject();
+        contentData.put("details", question);
+        contentElement.put("data", contentData);
+        content.put(contentElement);
+        body.put("content", content);
+        body.put("event", "send");
+        RequestEntity<String> requestEntity = null;
+        try {
+            requestEntity = RequestEntity.post(new URI(this.chatbotUrl))
+                    .body(body.toString());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        JSONObject responseBody = new JSONObject(this.restTemplate.exchange(requestEntity, String.class).getBody());
+        String answer = responseBody.getJSONArray("content")
+                .getJSONObject(0)
+                .getJSONObject("data")
+                .getString("details");
+
+        ChatbotConversation conversation = new ChatbotConversation();
+        conversation.setChatbotAnswer(answer);
+        conversation.setUserQuestion(question);
+        conversation.setAnswerTimeNDate(new Date());
+        conversation.setQuestionTimeNDate(new Date());
+        return conversation;
+    }
+}

--- a/src/test/java/com/kube/noon/customersupport/service/TestChatbotServiceImpl.java
+++ b/src/test/java/com/kube/noon/customersupport/service/TestChatbotServiceImpl.java
@@ -1,0 +1,21 @@
+package com.kube.noon.customersupport.service;
+
+import com.kube.noon.customersupport.domain.ChatbotConversation;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest
+class TestChatbotServiceImpl {
+
+    @Autowired
+    ChatbotServiceImpl chatbotService;
+
+    @Test
+    void test() {
+        ChatbotConversation ask = chatbotService.ask("NOON이 뭐야?");
+        log.info("ask={}", ask);
+    }
+}


### PR DESCRIPTION
## 요약
챗봇을 구현했습니다.

## 변경 사항 설명
- 학습된 Chatbot으로 API 요청

## 관련 이슈 및 참고 자료
#76

[Naver 공식 문서](https://guide.ncloud-docs.com/docs/chatbot-chatbot-overview)
[야, 너두 할 수 있어! 문과생의 톡톡 챗봇 제작기
](https://blog.naver.com/PostView.naver?blogId=n_cloudplatform&logNo=221901199311&redirect=Dlog&widgetTypeCall=true&topReferer=https%3A%2F%2Fwww.google.com%2F&trackingCode=external&directAccess=false)
ㄴ얘가 하라는 대로 하니까 다 됨