### PR TITLE
fix : FeedService 관련 버그 해결

### DIFF
--- a/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
+++ b/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
@@ -19,14 +19,14 @@ public class FeedRestController {
     private final FeedStatisticsService feedStatisticsService;
     private final FeedSubService feedSubService;
 
-    @GetMapping("/memberFeedList")
+    @GetMapping("/getFeedListByMember")
     public List<FeedSummaryDto> getMemberFeedList(@RequestParam String memberId) {
         List<FeedSummaryDto> feedListByMember = feedService.getFeedListByMember(memberId);
 
         return feedListByMember;
     }
 
-    @GetMapping("/buildingFeedList")
+    @GetMapping("/getFeedListByBuilding")
     public List<FeedSummaryDto> getBuildingFeedList(
             @RequestParam String memberId,
             @RequestParam int buildingId) {
@@ -35,21 +35,21 @@ public class FeedRestController {
         return feedListByBuilding;
     }
 
-    @GetMapping("/memberLikeFeedList")
+    @GetMapping("/getFeedListByMemberLike")
     public List<FeedSummaryDto> getMemberLikeFeedList(@RequestParam String memberId) {
         List<FeedSummaryDto> feedListByMemberLike = feedService.getFeedListByMemberLike(memberId);
 
         return feedListByMemberLike;
     }
 
-    @GetMapping("/bookmarkFeedList")
+    @GetMapping("/getFeedListByMemberBookmark")
     public List<FeedSummaryDto> getBookmarkFeedList(@RequestParam String memberId) {
         List<FeedSummaryDto> feedListByMemberBookmark = feedService.getFeedListByMemberBookmark(memberId);
 
         return feedListByMemberBookmark;
     }
 
-    @GetMapping("/buildingSubscriptionFeedList")
+    @GetMapping("/getFeedListByMemberSubscription")
     public List<FeedSummaryDto> getBuildingSubscriptionFeedList(@RequestParam String memberId) {
         List<FeedSummaryDto> feedListByBuildingSubscription = feedService.getFeedListByBuildingSubscription(memberId);
 

--- a/src/main/java/com/kube/noon/feed/domain/Feed.java
+++ b/src/main/java/com/kube/noon/feed/domain/Feed.java
@@ -24,9 +24,6 @@ public class Feed {
     @Column(name = "feed_id")
     private int feedId;
 
-//    @Column(name = "writer_id", length = 20, nullable = false)
-//    private String writerId;
-//
 //    @Column(name = "building_id")
 //    private int buildingId;
 
@@ -66,7 +63,7 @@ public class Feed {
     private List<TagFeed> tagFeeds;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "building_id")
+    @JoinColumn(name = "building_id", nullable = true)
     private Building building;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -83,7 +80,8 @@ public class Feed {
                 + " / buildingId : " + building.getBuildingId()
                 + " / feedTitle: " + title
                 + " / feedText: " + feedText
-                + " / activated : " + activated;
+                + " / activated : " + activated
+                + " / comments : " + comments;
     }
 
 }

--- a/src/main/java/com/kube/noon/feed/dto/FeedDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedDto.java
@@ -12,6 +12,7 @@ import com.kube.noon.member.repository.MemberRepository;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,28 +34,55 @@ public class FeedDto {
     private Long viewCnt;
     private LocalDateTime writtenTime;
     private FeedCategory feedCategory;
-    private boolean isModified;
-    private boolean isMainActivated;
-    private List<FeedComment> comments;
-    private List<TagFeed> tagFeeds;
+    private boolean modified;
+    private boolean mainActivate;
+    private boolean activate;
+    private List<FeedAttachmentDto> attachments;
+    private List<FeedCommentDto> comments;
+    private List<TagFeedDto> tagFeeds;
 
     public static FeedDto toDto(Feed feed) {
+        // NullPointException
+        Building building = feed.getBuilding();
+        if(building == null) {
+            building = Building.builder().build();
+        }
+
+        Member writer = feed.getWriter();
+        if(writer == null) {
+            writer = Member.builder().build();
+        }
+
         return FeedDto.builder()
                 .feedId(feed.getFeedId())
-                .writerId(feed.getWriter().getMemberId())
-                .writerNickname(feed.getWriter().getNickname())
-                .buildingId(feed.getBuilding().getBuildingId())
-                .buildingName(feed.getBuilding().getBuildingName())
+                .writerId(writer.getMemberId())
+                .writerNickname(writer.getNickname())
+                .buildingId(building.getBuildingId())
+                .buildingName(building.getBuildingName())
                 .publicRange(feed.getPublicRange())
                 .title(feed.getTitle())
                 .feedText(feed.getFeedText())
                 .viewCnt(feed.getViewCnt())
                 .writtenTime(feed.getWrittenTime())
                 .feedCategory(feed.getFeedCategory())
-                .isModified(feed.isModified())
-                .isMainActivated(feed.isMainActivated())
-                .comments(feed.getComments())
-                .tagFeeds(feed.getTagFeeds())
+                .modified(feed.isModified())
+                .mainActivate(feed.isMainActivated())
+                .activate(feed.isActivated())
+                .attachments(
+                        feed.getAttachments() == null ?
+                                Collections.emptyList() :
+                                feed.getAttachments().stream().map(FeedAttachmentDto::toDto).collect(Collectors.toList())
+                )
+                .comments(
+                        feed.getComments() == null ?
+                                Collections.emptyList() :
+                                feed.getComments().stream().map(FeedCommentDto::toDto).collect(Collectors.toList())
+                )
+                .tagFeeds(
+                        feed.getTagFeeds() == null ?
+                                Collections.emptyList() :
+                                feed.getTagFeeds().stream().map(TagFeedDto::toDto).collect(Collectors.toList())
+                )
                 .build();
     }
 
@@ -70,9 +98,23 @@ public class FeedDto {
                 .writtenTime(feedDto.getWrittenTime())
                 .feedCategory(feedDto.getFeedCategory())
                 .modified(feedDto.isModified())
-                .mainActivated(feedDto.isMainActivated())
-                .comments(feedDto.getComments())
-                .tagFeeds(feedDto.getTagFeeds())
+                .mainActivated(feedDto.isMainActivate())
+                .activated(feedDto.isActivate())
+                .attachments(
+                        feedDto.getAttachments() == null ?
+                                Collections.emptyList() :
+                                feedDto.getAttachments().stream().map(FeedAttachmentDto::toEntity).collect(Collectors.toList())
+                )
+                .comments(
+                        feedDto.getComments() == null ?
+                                Collections.emptyList() :
+                                feedDto.getComments().stream().map(FeedCommentDto::toEntity).collect(Collectors.toList())
+                )
+                .tagFeeds(
+                        feedDto.getTagFeeds() == null ?
+                                Collections.emptyList() :
+                                feedDto.getTagFeeds().stream().map(TagFeedDto::toEntity).collect(Collectors.toList())
+                )
                 .build();
     }
 

--- a/src/main/java/com/kube/noon/feed/dto/FeedSummaryDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedSummaryDto.java
@@ -30,7 +30,6 @@ public class FeedSummaryDto {
                 .title(feed.getTitle())
                 .feedText(feed.getFeedText())
                 .buildingId(feed.getBuilding().getBuildingId())
-                .buildingName(feed.getBuilding().getBuildingName())
                 .feedAttachementURL((feed.getAttachments() == null || feed.getAttachments().size() == 0) ? null : feed.getAttachments().get(0).getFileUrl())
                 .build();
     }

--- a/src/main/java/com/kube/noon/feed/dto/TagFeedDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/TagFeedDto.java
@@ -16,22 +16,22 @@ import java.util.stream.Collectors;
 @ToString
 public class TagFeedDto {
     private int tagFeedId;
-    private Feed feed;
-    private Tag tag;
+    private int feedId;
+    private int tagId;
 
     public static TagFeedDto toDto(TagFeed tagFeed) {
         return TagFeedDto.builder()
                 .tagFeedId(tagFeed.getTagFeedId())
-                .feed(tagFeed.getFeed())
-                .tag(tagFeed.getTag())
+                .feedId(tagFeed.getFeed().getFeedId())
+                .tagId(tagFeed.getTag().getTagId())
                 .build();
     }
 
     public static TagFeed toEntity(TagFeedDto tagFeedDto) {
         return TagFeed.builder()
                 .tagFeedId(tagFeedDto.getTagFeedId())
-                .feed(tagFeedDto.getFeed())
-                .tag(tagFeedDto.getTag())
+                .feed(Feed.builder().feedId(tagFeedDto.getFeedId()).build())
+                .tag(Tag.builder().tagId(tagFeedDto.getTagId()).build())
                 .build();
     }
 

--- a/src/main/java/com/kube/noon/feed/dto/TagFeedDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/TagFeedDto.java
@@ -2,7 +2,11 @@ package com.kube.noon.feed.dto;
 
 import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.feed.domain.Tag;
+import com.kube.noon.feed.domain.TagFeed;
 import lombok.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 @NoArgsConstructor
@@ -14,4 +18,25 @@ public class TagFeedDto {
     private int tagFeedId;
     private Feed feed;
     private Tag tag;
+
+    public static TagFeedDto toDto(TagFeed tagFeed) {
+        return TagFeedDto.builder()
+                .tagFeedId(tagFeed.getTagFeedId())
+                .feed(tagFeed.getFeed())
+                .tag(tagFeed.getTag())
+                .build();
+    }
+
+    public static TagFeed toEntity(TagFeedDto tagFeedDto) {
+        return TagFeed.builder()
+                .tagFeedId(tagFeedDto.getTagFeedId())
+                .feed(tagFeedDto.getFeed())
+                .tag(tagFeedDto.getTag())
+                .build();
+    }
+
+    public static List<TagFeedDto> toDtoList(List<TagFeed> tagFeedDtoList) {
+        return tagFeedDtoList.stream().map(TagFeedDto::toDto).collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/kube/noon/feed/repository/FeedRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/FeedRepository.java
@@ -72,7 +72,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
             INNER JOIN Zzim z ON f.feedId = z.feedId 
             WHERE z.zzimType = 'LIKE' 
             AND z.memberId = :#{#member.memberId} 
-            AND f.building.buildingId = :#{#building.buildingId}
+            AND f.building = :#{#building}
             AND f.activated = true 
             AND z.activated = true
           """)

--- a/src/main/java/com/kube/noon/feed/service/FeedService.java
+++ b/src/main/java/com/kube/noon/feed/service/FeedService.java
@@ -35,10 +35,10 @@ public interface FeedService {
     int addFeed(FeedDto feedDto);
 
     // 피드를 수정한다.
-    int updateFeed(FeedDto feedSummaryDto);
+    int updateFeed(FeedDto feedDto);
 
     // 피드를 삭제한다.
-    int deleteFeed(FeedDto feedSummaryDto);
+    int deleteFeed(FeedDto feedDto);
 
     // 피드 하나를 상세보기한다.
     FeedDto getFeedById(int feedId);

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
@@ -118,6 +118,7 @@ public class FeedServiceImpl implements FeedService {
     @Override
     public int addFeed(FeedDto feedDto) {
         Feed addFeed = FeedDto.toEntity(feedDto);
+        addFeed.setActivated(true);
         return feedRepository.save(addFeed).getFeedId();
     }
 

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
@@ -1,13 +1,13 @@
 package com.kube.noon.feed.service.impl;
 
 import com.kube.noon.building.domain.Building;
+import com.kube.noon.common.FeedCategory;
 import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.feed.dto.FeedDto;
 import com.kube.noon.feed.dto.FeedSummaryDto;
 import com.kube.noon.feed.repository.FeedRepository;
+import com.kube.noon.feed.repository.mybatis.FeedMyBatisRepository;
 import com.kube.noon.feed.service.FeedService;
-import com.kube.noon.feed.service.FeedStatisticsService;
-import com.kube.noon.feed.service.FeedSubService;
 import com.kube.noon.feed.service.recommend.FeedRecommendationMemberId;
 import com.kube.noon.member.domain.Member;
 import lombok.RequiredArgsConstructor;
@@ -25,9 +25,7 @@ import java.util.Random;
 public class FeedServiceImpl implements FeedService {
 
     private final FeedRepository feedRepository;
-
-    private final FeedSubService feedSubService;
-    private final FeedStatisticsService feedStatisticsService;
+    private final FeedMyBatisRepository feedMyBatisRepository;
 
     @Override
     public List<FeedSummaryDto> getFeedListByMember(String memberId) {
@@ -44,11 +42,10 @@ public class FeedServiceImpl implements FeedService {
 
     @Override
     public List<FeedSummaryDto> getFeedListByBuilding(String memberId, int buildingId) {
-        Member member = Member.builder().memberId(memberId).build();
         Building building = Building.builder().buildingId(buildingId).build();
         List<Feed> entities = new ArrayList<>();
 
-        FeedRecommendationMemberId.initData(feedStatisticsService.getMemberLikeTag());
+        FeedRecommendationMemberId.initData(feedMyBatisRepository.getMemberLikeTag());
         List<String> memberIdList = FeedRecommendationMemberId.getMemberLikeTagsRecommendation(memberId);
 
         // 추천 맴버가 없다면 빌딩 그대로 보여주기
@@ -118,6 +115,9 @@ public class FeedServiceImpl implements FeedService {
     @Override
     public int addFeed(FeedDto feedDto) {
         Feed addFeed = FeedDto.toEntity(feedDto);
+        if(addFeed.getFeedCategory() == FeedCategory.NOTICE) {
+            addFeed.setBuilding(null);
+        }
         addFeed.setActivated(true);
         return feedRepository.save(addFeed).getFeedId();
     }
@@ -127,6 +127,9 @@ public class FeedServiceImpl implements FeedService {
     public int updateFeed(FeedDto feedDto) {
         Feed updateFeed = feedRepository.findByFeedId(feedDto.getFeedId());
 
+        if(updateFeed.getFeedCategory() == FeedCategory.NOTICE) {
+            updateFeed.setBuilding(null);
+        }
         updateFeed.setTitle(feedDto.getTitle());
         updateFeed.setFeedText(feedDto.getFeedText());
         updateFeed.setModified(true);

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
@@ -12,7 +12,6 @@ import com.kube.noon.feed.dto.TagDto;
 import com.kube.noon.feed.repository.*;
 import com.kube.noon.feed.service.FeedSubService;
 import com.kube.noon.member.domain.Member;
-import com.kube.noon.member.dto.MemberProfileDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;

--- a/src/test/java/com/kube/noon/feed/repository/TestFeedRepository.java
+++ b/src/test/java/com/kube/noon/feed/repository/TestFeedRepository.java
@@ -8,10 +8,6 @@ import com.kube.noon.common.zzim.ZzimRepository;
 import com.kube.noon.common.zzim.ZzimType;
 import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.member.domain.Member;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.EntityTransaction;
-import jakarta.persistence.Persistence;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -175,7 +171,7 @@ public class TestFeedRepository {
         }
 
         // 2. 건물별 피드 목록 보기
-        List<Feed> getFeedListByBuildingId = feedRepository.findByBuildingAndActivatedTrue(Building.builder().buildingId(buildingId).build());
+        List<Feed> getFeedListByBuildingId = feedRepository.findByBuildingAndActivatedTrue(building);
         assertThat(getFeedListByBuildingId.size()).isGreaterThan(0);
         for(Feed f : getFeedListByBuildingId) {
             log.info(f.toString());
@@ -212,7 +208,7 @@ public class TestFeedRepository {
         // 7. 한 건물의 피드 중 특정 회원이 좋아요를 누른 피드 목록을 우선 정렬한다.
         List<Feed> getFeedWithLikesFirst = feedRepository.findFeedWithLikesFirst(writer, building);
         assertThat(getFeedListByMemberAndBuilding.size()).isGreaterThan(0);
-        for(Feed f : getFeedListByMemberAndBuilding) {
+        for(Feed f : getFeedWithLikesFirst) {
             log.info(f.toString());
         }
     }

--- a/src/test/java/com/kube/noon/feed/service/TestFeedServiceImpl.java
+++ b/src/test/java/com/kube/noon/feed/service/TestFeedServiceImpl.java
@@ -89,14 +89,14 @@ public class TestFeedServiceImpl {
         FeedDto feedDto = FeedDto.builder()
                 .writerId("member_15")
                 .buildingId(10015)
-                .isMainActivated(false)
+                .mainActivate(false)
                 .publicRange(PublicRange.PUBLIC)
                 .title("WinterHana Test")
                 .feedText("테스트 중입니다.")
                 .viewCnt(9999L)
                 .writtenTime(LocalDateTime.now())
                 .feedCategory(FeedCategory.GENERAL)
-                .isModified(false)
+                .modified(false)
                 .build();
 
         int feedId = feedServiceImpl.addFeed(feedDto);
@@ -183,7 +183,7 @@ public class TestFeedServiceImpl {
         FeedDto getFeedDto = feedServiceImpl.getFeedById(feedId);
 
         assertThat(getFeedDto).isNotNull();
-        assertThat(getFeedDto.isMainActivated()).isTrue();
+        assertThat(getFeedDto.isMainActivate()).isTrue();
     }
 
     /**


### PR DESCRIPTION
## 요약
발견된 버그들을 해결 및 완화하였습니다.

## 변경 사항 설명
1. 피드 상세보기를 가져올 시 (feed/detail/{feedId}), tagText 내에서 순환 참조 문제가 일어나는 현상 해결

tagFeedDto에서 순환 참조를 하고 있는 것으로 파악하여 이를 수정하였습니다.
```
public class TagFeedDto {
    private int tagFeedId;
    // private Feed feed;
    // private Tag tag;
    private int feedId;
    private int tagId;
...
}
```
2. addFeed 중 addNotice일 때 building이 굳이 필요 없는데 요구했던 현상 완화

연관관계를 아예 바꾸면 코드를 다시 다 고쳐야 해서 피드를 추가/수정 시 예외사항을 일단 뒀습니다.
```
    public int addFeed(FeedDto feedDto) {
        Feed addFeed = FeedDto.toEntity(feedDto);
        if(addFeed.getFeedCategory() == FeedCategory.NOTICE) {
            addFeed.setBuilding(null);
        }
        addFeed.setActivated(true);
...
    public int updateFeed(FeedDto feedDto) {
        Feed updateFeed = feedRepository.findByFeedId(feedDto.getFeedId());

        if(updateFeed.getFeedCategory() == FeedCategory.NOTICE) {
            updateFeed.setBuilding(null);
        }
        updateFeed.setTitle(feedDto.getTitle());
        updateFeed.setFeedText(feedDto.getFeedText());
        updateFeed.setModified(true)
...
```
일단 임시로 해두고 더 좋은 알고리즘이 있으면 바로 수정하겠습니다.

## 관련 이슈 및 참고 자료
없음
