### PR TITLE
feat, docs : FeedController 테스트 완료, 목록 페이징 작업, Swagger 명세화

### DIFF
--- a/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
+++ b/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
@@ -19,39 +19,51 @@ public class FeedRestController {
     private final FeedStatisticsService feedStatisticsService;
     private final FeedSubService feedSubService;
 
+    private static final int PAGE_SIZE = 10;        // 일단 static final로 설정, 나중에 메타데이터로 뺄 예정
+
     @GetMapping("/getFeedListByMember")
-    public List<FeedSummaryDto> getMemberFeedList(@RequestParam String memberId) {
-        List<FeedSummaryDto> feedListByMember = feedService.getFeedListByMember(memberId);
+    public List<FeedSummaryDto> getMemberFeedList(
+            @RequestParam String memberId,
+            @RequestParam(required = false, defaultValue = "1") int page) {
+        List<FeedSummaryDto> feedListByMember = feedService.getFeedListByMember(memberId, page - 1, PAGE_SIZE);
 
         return feedListByMember;
     }
 
+
     @GetMapping("/getFeedListByBuilding")
     public List<FeedSummaryDto> getBuildingFeedList(
             @RequestParam String memberId,
-            @RequestParam int buildingId) {
-        List<FeedSummaryDto> feedListByBuilding = feedService.getFeedListByBuilding(memberId, buildingId);
+            @RequestParam int buildingId,
+            @RequestParam(required = false, defaultValue = "1") int page) {
+        List<FeedSummaryDto> feedListByBuilding = feedService.getFeedListByBuilding(memberId, buildingId, page - 1, PAGE_SIZE);
 
         return feedListByBuilding;
     }
 
     @GetMapping("/getFeedListByMemberLike")
-    public List<FeedSummaryDto> getMemberLikeFeedList(@RequestParam String memberId) {
-        List<FeedSummaryDto> feedListByMemberLike = feedService.getFeedListByMemberLike(memberId);
+    public List<FeedSummaryDto> getMemberLikeFeedList(
+            @RequestParam String memberId,
+            @RequestParam(required = false, defaultValue = "1") int page) {
+        List<FeedSummaryDto> feedListByMemberLike = feedService.getFeedListByMemberLike(memberId, page - 1, PAGE_SIZE);
 
         return feedListByMemberLike;
     }
 
     @GetMapping("/getFeedListByMemberBookmark")
-    public List<FeedSummaryDto> getBookmarkFeedList(@RequestParam String memberId) {
-        List<FeedSummaryDto> feedListByMemberBookmark = feedService.getFeedListByMemberBookmark(memberId);
+    public List<FeedSummaryDto> getBookmarkFeedList(
+            @RequestParam String memberId,
+            @RequestParam(required = false, defaultValue = "1") int page) {
+        List<FeedSummaryDto> feedListByMemberBookmark = feedService.getFeedListByMemberBookmark(memberId, page - 1, PAGE_SIZE);
 
         return feedListByMemberBookmark;
     }
 
     @GetMapping("/getFeedListByMemberSubscription")
-    public List<FeedSummaryDto> getBuildingSubscriptionFeedList(@RequestParam String memberId) {
-        List<FeedSummaryDto> feedListByBuildingSubscription = feedService.getFeedListByBuildingSubscription(memberId);
+    public List<FeedSummaryDto> getBuildingSubscriptionFeedList(
+            @RequestParam String memberId,
+            @RequestParam(required = false, defaultValue = "1") int page) {
+        List<FeedSummaryDto> feedListByBuildingSubscription = feedService.getFeedListByBuildingSubscription(memberId, page - 1, PAGE_SIZE);
 
         return feedListByBuildingSubscription;
     }
@@ -77,8 +89,8 @@ public class FeedRestController {
         return deleteFeedId;
     }
 
-    @GetMapping("/detail/{feedId}")
-    public FeedDto getFeed(@PathVariable int feedId) {
+    @GetMapping("/detail")
+    public FeedDto getFeed(@RequestParam int feedId) {
         FeedDto getFeedDto = feedService.getFeedById(feedId);
 
         return getFeedDto;
@@ -106,8 +118,8 @@ public class FeedRestController {
         return cntUpFeedId;
     }
 
-    @GetMapping("/getFeedAttachmentList/{feedId}")
-    public List<FeedAttachmentDto> getFeedAttachmentList(@PathVariable("feedId") int feedId) {
+    @GetMapping("/getFeedAttachmentList")
+    public List<FeedAttachmentDto> getFeedAttachmentList(@RequestParam int feedId) {
         List<FeedAttachmentDto> result = feedSubService.getFeedAttachmentList(feedId);
 
         return result;
@@ -163,8 +175,8 @@ public class FeedRestController {
         return zzimId;
     }
 
-    @GetMapping("/getFeedLikeList/{feedId}")
-    public List<FeedLIkeMemberDto> getFeedLikeList(@PathVariable("feedId") int feedId) {
+    @GetMapping("/getFeedLikeList")
+    public List<FeedLIkeMemberDto> getFeedLikeList(@RequestParam int feedId) {
         return feedSubService.getFeedLikeList(feedId);
     }
 
@@ -183,8 +195,8 @@ public class FeedRestController {
         return feedSubService.updateFeedCommnet(feedCommentDto);
     }
 
-    @GetMapping("/feedTagList/{feedId}")
-    public List<TagDto> getFeedTagList(@PathVariable("feedId") int feedId) {
+    @GetMapping("/feedTagList")
+    public List<TagDto> getFeedTagList(@RequestParam int feedId) {
         return feedSubService.getFeedTagList(feedId);
     }
 
@@ -198,8 +210,8 @@ public class FeedRestController {
         return feedSubService.addFeedTag(addTagDto.getFeedId(), addTagDto.getTagText());
     }
 
-    @GetMapping("/feedViewCuntByBuilding/{buildingId}")
-    public List<FeedViewCntByBuildingDto> getFeedViewCntByBuilding(@PathVariable("buildingId") int buildingId) {
+    @GetMapping("/feedViewCuntByBuilding")
+    public List<FeedViewCntByBuildingDto> getFeedViewCntByBuilding(@RequestParam int buildingId) {
         return feedStatisticsService.getFeedViewCntByBuilding(buildingId);
     }
 
@@ -208,8 +220,8 @@ public class FeedRestController {
         return feedStatisticsService.getFeedCntByTag();
     }
 
-    @GetMapping("/FeedPopularity/{buildingId}")
-    public List<FeedPopularityDto> getFeedPopularity(@PathVariable("buildingId") int buildingId) {
+    @GetMapping("/FeedPopularity")
+    public List<FeedPopularityDto> getFeedPopularity(@RequestParam int buildingId) {
         return feedStatisticsService.getFeedPopularity(buildingId);
     }
 }

--- a/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
+++ b/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
@@ -70,9 +70,9 @@ public class FeedRestController {
         return feedId;
     }
 
-    @PostMapping("/deleteFeed")
-    public int deleteFeed(@RequestBody FeedDto feedDto) {
-        int deleteFeedId = feedService.deleteFeed(feedDto);
+    @PostMapping("/deleteFeed/{feedId}")
+    public int deleteFeed(@PathVariable int feedId) {
+        int deleteFeedId = feedService.deleteFeed(feedId);
 
         return deleteFeedId;
     }
@@ -84,6 +84,7 @@ public class FeedRestController {
         return getFeedDto;
     }
 
+    // 필요 조건 : feedId, memberId
     @PostMapping("/setMainFeed")
     public int setMainFeed(@RequestBody FeedDto feedDto) {
         int mainFeedId = feedService.setMainFeed(feedDto);
@@ -105,7 +106,7 @@ public class FeedRestController {
         return cntUpFeedId;
     }
 
-    @GetMapping("/feedAttachmentList/{feedId}")
+    @GetMapping("/getFeedAttachmentList/{feedId}")
     public List<FeedAttachmentDto> getFeedAttachmentList(@PathVariable("feedId") int feedId) {
         List<FeedAttachmentDto> result = feedSubService.getFeedAttachmentList(feedId);
 
@@ -119,9 +120,9 @@ public class FeedRestController {
         return attachmentId;
     }
 
-    @PostMapping("/deleteFeedAttachment")
-    public int deleteFeedAttachment(@RequestBody FeedAttachmentDto feedAttachmentDto) {
-        int deleteAttachmentId = feedSubService.deleteFeedAttachment(feedAttachmentDto.getAttachmentId());
+    @PostMapping("/deleteFeedAttachment/{attachmentId}")
+    public int deleteFeedAttachment(@PathVariable("attachmentId") int attachmentId) {
+        int deleteAttachmentId = feedSubService.deleteFeedAttachment(attachmentId);
 
         return deleteAttachmentId;
     }
@@ -162,7 +163,7 @@ public class FeedRestController {
         return zzimId;
     }
 
-    @GetMapping("/feedLikeList/{feedId}")
+    @GetMapping("/getFeedLikeList/{feedId}")
     public List<FeedLIkeMemberDto> getFeedLikeList(@PathVariable("feedId") int feedId) {
         return feedSubService.getFeedLikeList(feedId);
     }
@@ -172,7 +173,7 @@ public class FeedRestController {
         return feedSubService.addFeedComment(feedCommentDto);
     }
 
-    @PostMapping("/deleteFeedList/{commentId}")
+    @PostMapping("/deleteFeedComment/{commentId}")
     public int deleteFeedComment(@PathVariable("commentId") int commentId) {
         return feedSubService.deleteFeedComment(commentId);
     }
@@ -187,18 +188,14 @@ public class FeedRestController {
         return feedSubService.getFeedTagList(feedId);
     }
 
-    @PostMapping("/addFeedTag/{feedId}/{tagText}")
-    public int addFeedTag(
-            @PathVariable("feedId") int feedId,
-            @PathVariable("tagText") String memberId) {
-        return feedSubService.addFeedTag(feedId, memberId);
+    @PostMapping("/addFeedTag")
+    public int addFeedTag(@RequestBody AddTagDto addTagDto) {
+        return feedSubService.addFeedTag(addTagDto.getFeedId(), addTagDto.getTagText());
     }
 
-    @PostMapping("/deleteFeedTag/{feedId}/{tagText}")
-    public int deleteFeedTag(
-            @PathVariable("feedId") int feedId,
-            @PathVariable("tagText") String memberId) {
-        return feedSubService.addFeedTag(feedId, memberId);
+    @PostMapping("/deleteFeedTag")
+    public int deleteFeedTag(@RequestBody AddTagDto addTagDto) {
+        return feedSubService.addFeedTag(addTagDto.getFeedId(), addTagDto.getTagText());
     }
 
     @GetMapping("/feedViewCuntByBuilding/{buildingId}")

--- a/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
+++ b/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
@@ -4,6 +4,9 @@ import com.kube.noon.feed.dto.*;
 import com.kube.noon.feed.service.FeedService;
 import com.kube.noon.feed.service.FeedStatisticsService;
 import com.kube.noon.feed.service.FeedSubService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +17,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/feed")
+@Tag(name = "Feed", description = "피드 기능 API")
 public class FeedRestController {
     private final FeedService feedService;
     private final FeedStatisticsService feedStatisticsService;
@@ -21,53 +25,58 @@ public class FeedRestController {
 
     private static final int PAGE_SIZE = 10;        // 일단 static final로 설정, 나중에 메타데이터로 뺄 예정
 
+    @Operation(summary = "회원 피드 목록 조회", description = "회원이 작성한 피드 목록을 가져옵니다.")
     @GetMapping("/getFeedListByMember")
     public List<FeedSummaryDto> getMemberFeedList(
-            @RequestParam String memberId,
-            @RequestParam(required = false, defaultValue = "1") int page) {
+            @Parameter(description = "회원 ID") @RequestParam String memberId,
+            @Parameter(description = "가져올 페이지(default = 1)") @RequestParam(required = false, defaultValue = "1") int page) {
         List<FeedSummaryDto> feedListByMember = feedService.getFeedListByMember(memberId, page - 1, PAGE_SIZE);
 
         return feedListByMember;
     }
 
-
+    @Operation(summary = "건물 피드 목록 조회", description = "건물 내 작성된 피드 목록을 가져옵니다.")
     @GetMapping("/getFeedListByBuilding")
     public List<FeedSummaryDto> getBuildingFeedList(
-            @RequestParam String memberId,
-            @RequestParam int buildingId,
-            @RequestParam(required = false, defaultValue = "1") int page) {
+            @Parameter(description = "추천 알고리즘을 위한 회원 ID") @RequestParam String memberId,
+            @Parameter(description = "건물 ID") @RequestParam int buildingId,
+            @Parameter(description = "가져올 페이지(default = 1)")@RequestParam(required = false, defaultValue = "1") int page) {
         List<FeedSummaryDto> feedListByBuilding = feedService.getFeedListByBuilding(memberId, buildingId, page - 1, PAGE_SIZE);
 
         return feedListByBuilding;
     }
 
+    @Operation(summary = "회원의 좋아요 피드 목록 조회", description = "회원이 좋아요를 누른 피드 목록을 가져옵니다.")
     @GetMapping("/getFeedListByMemberLike")
     public List<FeedSummaryDto> getMemberLikeFeedList(
-            @RequestParam String memberId,
-            @RequestParam(required = false, defaultValue = "1") int page) {
+            @Parameter(description = "회원 ID") @RequestParam String memberId,
+            @Parameter(description = "가져올 페이지(default = 1)") @RequestParam(required = false, defaultValue = "1") int page) {
         List<FeedSummaryDto> feedListByMemberLike = feedService.getFeedListByMemberLike(memberId, page - 1, PAGE_SIZE);
 
         return feedListByMemberLike;
     }
 
+    @Operation(summary = "회원의 북마크 피드 목록 조회", description = "회원이 북마크를 등록한 피드 목록을 가져옵니다.")
     @GetMapping("/getFeedListByMemberBookmark")
     public List<FeedSummaryDto> getBookmarkFeedList(
-            @RequestParam String memberId,
-            @RequestParam(required = false, defaultValue = "1") int page) {
+            @Parameter(description = "회원 ID") @RequestParam String memberId,
+            @Parameter(description = "가져올 페이지(default = 1)") @RequestParam(required = false, defaultValue = "1") int page) {
         List<FeedSummaryDto> feedListByMemberBookmark = feedService.getFeedListByMemberBookmark(memberId, page - 1, PAGE_SIZE);
 
         return feedListByMemberBookmark;
     }
 
+    @Operation(summary = "회원의 구독한 건물 피드 목록 조회", description = "회원이 구독한 건물의 피드 목록을 조회합니다.")
     @GetMapping("/getFeedListByMemberSubscription")
     public List<FeedSummaryDto> getBuildingSubscriptionFeedList(
-            @RequestParam String memberId,
-            @RequestParam(required = false, defaultValue = "1") int page) {
+            @Parameter(description = "회원 ID") @RequestParam String memberId,
+            @Parameter(description = "가져올 페이지(default = 1)") @RequestParam(required = false, defaultValue = "1") int page) {
         List<FeedSummaryDto> feedListByBuildingSubscription = feedService.getFeedListByBuildingSubscription(memberId, page - 1, PAGE_SIZE);
 
         return feedListByBuildingSubscription;
     }
 
+    @Operation(summary = "피드 추가", description = "피드를 하나 추가합니다.")
     @PostMapping("/addFeed")
     public int addFeed(@RequestBody FeedDto feedDto) {
         int feedId = feedService.addFeed(feedDto);
@@ -75,6 +84,7 @@ public class FeedRestController {
         return feedId;
     }
 
+    @Operation(summary = "피드 수정", description = "피드를 하나 수정합니다. 제목과 텍스트, 카테고리만 수정 가능합니다.")
     @PostMapping("/updateFeed")
     public int updateFeed(@RequestBody FeedDto feedDto) {
         int feedId = feedService.updateFeed(feedDto);
@@ -82,21 +92,23 @@ public class FeedRestController {
         return feedId;
     }
 
+    @Operation(summary = "피드 삭제", description = "피드를 하나 삭제합니다.")
     @PostMapping("/deleteFeed/{feedId}")
-    public int deleteFeed(@PathVariable int feedId) {
+    public int deleteFeed(@Parameter(description = "삭제할 피드 ID") @PathVariable int feedId) {
         int deleteFeedId = feedService.deleteFeed(feedId);
 
         return deleteFeedId;
     }
 
+    @Operation(summary = "피드 상세보기", description = "피드를 하나 상세보기합니다.")
     @GetMapping("/detail")
-    public FeedDto getFeed(@RequestParam int feedId) {
+    public FeedDto getFeed(@Parameter(description = "상세보기할 피드 ID") @RequestParam int feedId) {
         FeedDto getFeedDto = feedService.getFeedById(feedId);
 
         return getFeedDto;
     }
-
-    // 필요 조건 : feedId, memberId
+    
+    @Operation(summary = "메인 피드 설정", description = "자신의 피드 중 메인 피드를 하나 설정합니다. (사용하는 정보 : 피드 ID, 회원 ID)")
     @PostMapping("/setMainFeed")
     public int setMainFeed(@RequestBody FeedDto feedDto) {
         int mainFeedId = feedService.setMainFeed(feedDto);
@@ -104,27 +116,31 @@ public class FeedRestController {
         return mainFeedId;
     }
 
+    @Operation(summary = "피드 검색하기", description = "피드 제목이나 내용을 검색한 결과를 가져옵니다.")
     @GetMapping("/search")
-    public List<FeedSummaryDto> searchFeed(@RequestParam String keyword) {
+    public List<FeedSummaryDto> searchFeed(@Parameter(description = "검색할 키워드") @RequestParam String keyword) {
         List<FeedSummaryDto> result = feedService.searchFeedList(keyword);
 
         return result;
     }
 
+    @Operation(summary = "피드 조회수 증가", description = "피드의 조회수를 1 증가시킵니다.")
     @PostMapping("/viewCutUp/{feedId}")
-    public int viewCutUp(@PathVariable("feedId") int feedId) {
+    public int viewCutUp(@Parameter(description = "조회수를 증가시킬 피드 ID") @PathVariable("feedId") int feedId) {
         int cntUpFeedId = feedService.setViewCntUp(feedId);
 
         return cntUpFeedId;
     }
 
+    @Operation(summary = "피드의 첨부파일 목록 조회", description = "피드에 첨부된 파일 목록을 가져옵니다.")
     @GetMapping("/getFeedAttachmentList")
-    public List<FeedAttachmentDto> getFeedAttachmentList(@RequestParam int feedId) {
+    public List<FeedAttachmentDto> getFeedAttachmentList(@Parameter(description = "첨부파일을 조회할 피드 ID") @RequestParam int feedId) {
         List<FeedAttachmentDto> result = feedSubService.getFeedAttachmentList(feedId);
 
         return result;
     }
 
+    @Operation(summary = "피드 내 첨부파일 추가", description = "피드에 첨부파일 하나를 추가합니다.")
     @PostMapping("/addFeedAttachment")
     public int addFeedAttachment(@RequestBody FeedAttachmentDto feedAttachmentDto) {
         int attachmentId = feedSubService.addFeedAttachment(feedAttachmentDto);
@@ -132,94 +148,109 @@ public class FeedRestController {
         return attachmentId;
     }
 
+    @Operation(summary = "피드 내 첨부파일 삭제", description = "피드에 첨부파일 하나를 삭제합니다.")
     @PostMapping("/deleteFeedAttachment/{attachmentId}")
-    public int deleteFeedAttachment(@PathVariable("attachmentId") int attachmentId) {
+    public int deleteFeedAttachment(@Parameter(description = "삭제할 첨부파일 ID") @PathVariable("attachmentId") int attachmentId) {
         int deleteAttachmentId = feedSubService.deleteFeedAttachment(attachmentId);
 
         return deleteAttachmentId;
     }
 
+    @Operation(summary = "피드의 좋아요 등록", description = "하나의 피드에 좋아요를 등록합니다.")
     @PostMapping("/addFeedLike/{feedId}/{memberId}")
     public int addFeedLike(
-            @PathVariable("feedId") int feedId,
-            @PathVariable("memberId") String memberId) {
+            @Parameter(description = "좋아요를 할 피드 ID") @PathVariable("feedId") int feedId,
+            @Parameter(description = "좋아요를 누르는 회원 ID") @PathVariable("memberId") String memberId) {
         int zzimId = feedSubService.addFeedLike(feedId, memberId);
 
         return zzimId;
     }
 
+    @Operation(summary = "피드의 좋아요 삭제", description = "등록한 피드의 좋아요를 삭제합니다.")
     @PostMapping("/deleteFeedLike/{feedId}/{memberId}")
     public int deleteFeedLike(
-            @PathVariable("feedId") int feedId,
-            @PathVariable("memberId") String memberId) {
+            @Parameter(description = "좋아요를 취소할 피드 ID") @PathVariable("feedId") int feedId,
+            @Parameter(description = "좋아요를 취소하는 회원 ID") @PathVariable("memberId") String memberId) {
         int zzimId = feedSubService.deleteFeedLike(feedId, memberId);
 
         return zzimId;
     }
 
+    @Operation(summary = "피드의 북마크 등록", description = "하나의 피드에 북마크를 등록합니다.")
     @PostMapping("/addbookmark/{feedId}/{memberId}")
     public int addFeedBookmark(
-            @PathVariable("feedId") int feedId,
-            @PathVariable("memberId") String memberId) {
+            @Parameter(description = "북마크를 등록할 피드 ID") @PathVariable("feedId") int feedId,
+            @Parameter(description = "북마크를 등록하는 회원 ID") @PathVariable("memberId") String memberId) {
         int zzimId = feedSubService.addFeedBookmark(feedId, memberId);
 
         return zzimId;
     }
 
+    @Operation(summary = "피드의 북마크 취소", description = "등록한 피드의 북마크를 취소합니다.")
     @PostMapping("/deleteBookmark/{feedId}/{memberId}")
     public int deleteFeedBookmark(
-            @PathVariable("feedId") int feedId,
-            @PathVariable("memberId") String memberId) {
+            @Parameter(description = "북마크를 취소할 피드 ID") @PathVariable("feedId") int feedId,
+            @Parameter(description = "북마크를 취소하는 회원 ID") @PathVariable("memberId") String memberId) {
         int zzimId = feedSubService.deleteFeedBookmark(feedId, memberId);
 
         return zzimId;
     }
 
+    @Operation(summary = "피드의 좋아요를 누른 회원 조회", description = "하나의 피드 내에 좋아요를 누르는 회원 목록을 조회합니다.")
     @GetMapping("/getFeedLikeList")
-    public List<FeedLIkeMemberDto> getFeedLikeList(@RequestParam int feedId) {
+    public List<FeedLIkeMemberDto> getFeedLikeList(@Parameter(description = "목록을 조회할 피드 ID") @RequestParam int feedId) {
         return feedSubService.getFeedLikeList(feedId);
     }
 
+    @Operation(summary = "피드 댓글 추가", description = "하나의 피드에 댓글을 추가합니다.")
     @PostMapping("/addFeedComment")
     public int addFeedComment(@RequestBody FeedCommentDto feedCommentDto) {
         return feedSubService.addFeedComment(feedCommentDto);
     }
 
+    @Operation(summary = "피드 댓글 삭제", description = "댓글을 삭제합니다.")
     @PostMapping("/deleteFeedComment/{commentId}")
-    public int deleteFeedComment(@PathVariable("commentId") int commentId) {
+    public int deleteFeedComment(@Parameter(description = "삭제할 댓글 ID") @PathVariable("commentId") int commentId) {
         return feedSubService.deleteFeedComment(commentId);
     }
 
+    @Operation(summary = "피드 댓글 수정", description = "댓글을 수정합니다.")
     @PostMapping("/updateFeedComment")
     public int updateFeedComment(@RequestBody FeedCommentDto feedCommentDto) {
         return feedSubService.updateFeedCommnet(feedCommentDto);
     }
 
+    @Operation(summary = "피드 내 태그 목록 조회", description = "피드에 등록된 태그 목록을 가져옵니다.")
     @GetMapping("/feedTagList")
-    public List<TagDto> getFeedTagList(@RequestParam int feedId) {
+    public List<TagDto> getFeedTagList(@Parameter(description = "피드 목록을 가져올 피드 ID") @RequestParam int feedId) {
         return feedSubService.getFeedTagList(feedId);
     }
 
+    @Operation(summary = "태그 추가", description = "피드 내 태그를 추가합니다.")
     @PostMapping("/addFeedTag")
     public int addFeedTag(@RequestBody AddTagDto addTagDto) {
         return feedSubService.addFeedTag(addTagDto.getFeedId(), addTagDto.getTagText());
     }
 
+    @Operation(summary = "태그 삭제", description = "피드 내 태그를 삭제합니다.")
     @PostMapping("/deleteFeedTag")
     public int deleteFeedTag(@RequestBody AddTagDto addTagDto) {
-        return feedSubService.addFeedTag(addTagDto.getFeedId(), addTagDto.getTagText());
+        return feedSubService.deleteFeedTag(addTagDto.getFeedId(), addTagDto.getTagText());
     }
 
+    @Operation(summary = "[통계] 건물별 조회수가 높은 피드 목록", description = "건물 내에서 조회수가 높은 피드 5개를 가져옵니다.")
     @GetMapping("/feedViewCuntByBuilding")
-    public List<FeedViewCntByBuildingDto> getFeedViewCntByBuilding(@RequestParam int buildingId) {
+    public List<FeedViewCntByBuildingDto> getFeedViewCntByBuilding(@Parameter(description = "목록을 가져올 건물 ID") @RequestParam int buildingId) {
         return feedStatisticsService.getFeedViewCntByBuilding(buildingId);
     }
 
+    @Operation(summary = "[통계] 인기 많은 태그 목록", description = "많이 사용되는 태그 5개를 가져옵니다.")
     @GetMapping("/feedCntByTag")
     public List<FeedCntByTagDto> getFeedViewCntByBuilding() {
         return feedStatisticsService.getFeedCntByTag();
     }
 
+    @Operation(summary = "[통계] 건물별 인기도가 높은 피드 목록", description = "건물 내에서 인기도가 높은 피드 5개를 가져옵니다.")
     @GetMapping("/FeedPopularity")
     public List<FeedPopularityDto> getFeedPopularity(@RequestParam int buildingId) {
         return feedStatisticsService.getFeedPopularity(buildingId);

--- a/src/main/java/com/kube/noon/feed/dto/AddTagDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/AddTagDto.java
@@ -1,0 +1,17 @@
+package com.kube.noon.feed.dto;
+
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+/**
+ * 태그 삽입, 삭제 시 사용
+ */
+public class AddTagDto {
+    private int feedId;
+    private String tagText;
+}

--- a/src/main/java/com/kube/noon/feed/repository/TagRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/TagRepository.java
@@ -10,18 +10,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
-//    /**
-//     * 각 피드에 붙어있는 피드의 내용을 가져온다.
-//     * @param feed
-//     * @return
-//     */
-//    @Query("""
-//        SELECT t
-//        FROM TagFeed f
-//                 INNER JOIN Tag t ON f.tag.tagId = t.tagId
-//        WHERE f.feed.feedId = :#{#feed.feedId}
-//        """)
-//    List<Tag> getTagByFeedId(@Param("feed") Feed feed);
 
      /**
       * 각 피드에 붙어있는 피드의 내용을 가져온다.

--- a/src/main/java/com/kube/noon/feed/service/FeedService.java
+++ b/src/main/java/com/kube/noon/feed/service/FeedService.java
@@ -15,21 +15,27 @@ import java.util.List;
 public interface FeedService {
     // 회원별 피드 목록을 가져온다,
     List<FeedSummaryDto> getFeedListByMember(String memberId);
+    List<FeedSummaryDto> getFeedListByMember(String memberId, int page, int pageSize);
 
     // 건물별 피드 목록을 가져온다. 필요에 따라 피드를 추천한다.
     List<FeedSummaryDto> getFeedListByBuilding(String memberId, int buildingId);
+    List<FeedSummaryDto> getFeedListByBuilding(String memberId, int buildingId, int page, int pageSize);
 
     // 건물별 피드 목록을 가져온다.
     List<FeedSummaryDto> getFeedListByBuilding(int buildingId);
+    List<FeedSummaryDto> getFeedListByBuilding(int buildingId, int page, int pageSize);
 
     // 회원이 좋아요를 누른 피드 목록을 가져온다.
     List<FeedSummaryDto> getFeedListByMemberLike(String memberId);
+    List<FeedSummaryDto> getFeedListByMemberLike(String memberId, int page, int pageSize);
 
     // 회원이 북마크를 누른 피드 목록을 가져온다.
     List<FeedSummaryDto> getFeedListByMemberBookmark(String memberId);
+    List<FeedSummaryDto> getFeedListByMemberBookmark(String memberId, int page, int pageSize);
 
     // 회원이 건물을 구독한 피드 목록을 가져온다.
     List<FeedSummaryDto> getFeedListByBuildingSubscription(String memberId);
+    List<FeedSummaryDto> getFeedListByBuildingSubscription(String memberId, int page, int pageSize);
 
     // 피드를 추가한다.
     int addFeed(FeedDto feedDto);

--- a/src/main/java/com/kube/noon/feed/service/FeedService.java
+++ b/src/main/java/com/kube/noon/feed/service/FeedService.java
@@ -38,7 +38,7 @@ public interface FeedService {
     int updateFeed(FeedDto feedDto);
 
     // 피드를 삭제한다.
-    int deleteFeed(FeedDto feedDto);
+    int deleteFeed(int feedId);
 
     // 피드 하나를 상세보기한다.
     FeedDto getFeedById(int feedId);

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
@@ -139,8 +139,8 @@ public class FeedServiceImpl implements FeedService {
 
     @Transactional
     @Override
-    public int deleteFeed(FeedDto feedDto) {
-        Feed deleteFeed = feedRepository.findByFeedId(feedDto.getFeedId());
+    public int deleteFeed(int feedId) {
+        Feed deleteFeed = feedRepository.findByFeedId(feedId);
 
         deleteFeed.setActivated(false);
         return feedRepository.save(deleteFeed).getFeedId();
@@ -176,6 +176,12 @@ public class FeedServiceImpl implements FeedService {
 
         // 2. 새로운 대표 피드 등록
         Feed setMainFeed = feedRepository.findByFeedId(feedDto.getFeedId());
+
+        // 만약 피드가 없거나 자신의 피드가 아니라면 -1 반환
+        if(setMainFeed == null || !setMainFeed.getWriter().equals(feedDto.getWriterId())) {
+            return -1;
+        }
+
         setMainFeed.setMainActivated(true);
         return feedRepository.save(setMainFeed).getFeedId();
     }

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
@@ -12,6 +12,8 @@ import com.kube.noon.feed.service.recommend.FeedRecommendationMemberId;
 import com.kube.noon.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +35,20 @@ public class FeedServiceImpl implements FeedService {
                 Member.builder()
                         .memberId(memberId)
                         .build()
+        );
+
+        List<FeedSummaryDto> feedListByMember = FeedSummaryDto.toDtoList(entities);
+
+        return feedListByMember;
+    }
+
+    @Override
+    public List<FeedSummaryDto> getFeedListByMember(String memberId, int page, int pageSize) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+
+        List<Feed> entities = feedRepository.findByWriterAndActivatedTrue(
+                Member.builder().memberId(memberId).build(),
+                pageable
         );
 
         List<FeedSummaryDto> feedListByMember = FeedSummaryDto.toDtoList(entities);
@@ -65,9 +81,45 @@ public class FeedServiceImpl implements FeedService {
     }
 
     @Override
+    public List<FeedSummaryDto> getFeedListByBuilding(String memberId, int buildingId, int page, int pageSize) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+
+        Building building = Building.builder().buildingId(buildingId).build();
+        List<Feed> entities = new ArrayList<>();
+
+        FeedRecommendationMemberId.initData(feedMyBatisRepository.getMemberLikeTag());
+        List<String> memberIdList = FeedRecommendationMemberId.getMemberLikeTagsRecommendation(memberId);
+
+        // 추천 맴버가 없다면 빌딩 그대로 보여주기
+        if(memberIdList == null || memberIdList.isEmpty()) {
+            entities = feedRepository.findByBuildingAndActivatedTrue(building, pageable);
+        } else {
+            Random rand = new Random();
+            String recommandMemberId = memberIdList.get(rand.nextInt(memberIdList.size()));
+            Member recommandMember = Member.builder().memberId(recommandMemberId).build();
+
+            entities = feedRepository.findFeedWithLikesFirst(recommandMember, building, pageable);
+        }
+
+        List<FeedSummaryDto> feedListByBuilding = FeedSummaryDto.toDtoList(entities);
+
+        return feedListByBuilding;
+    }
+
+    @Override
     public List<FeedSummaryDto> getFeedListByBuilding(int buildingId) {
         Building building = Building.builder().buildingId(buildingId).build();
         List<Feed> entities = feedRepository.findByBuildingAndActivatedTrue(building);
+
+        return FeedSummaryDto.toDtoList(entities);
+    }
+
+    @Override
+    public List<FeedSummaryDto> getFeedListByBuilding(int buildingId, int page, int pageSize) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+
+        Building building = Building.builder().buildingId(buildingId).build();
+        List<Feed> entities = feedRepository.findByBuildingAndActivatedTrue(building, pageable);
 
         return FeedSummaryDto.toDtoList(entities);
     }
@@ -78,6 +130,19 @@ public class FeedServiceImpl implements FeedService {
                 Member.builder()
                         .memberId(memberId)
                         .build()
+        );
+
+        List<FeedSummaryDto> feedListByMemberLike = FeedSummaryDto.toDtoList(entites);
+
+        return feedListByMemberLike;
+    }
+
+    @Override
+    public List<FeedSummaryDto> getFeedListByMemberLike(String memberId, int page, int pageSize) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+
+        List<Feed> entites = feedRepository.findByMemberLikeFeed(
+                Member.builder().memberId(memberId).build(), pageable
         );
 
         List<FeedSummaryDto> feedListByMemberLike = FeedSummaryDto.toDtoList(entites);
@@ -99,11 +164,37 @@ public class FeedServiceImpl implements FeedService {
     }
 
     @Override
+    public List<FeedSummaryDto> getFeedListByMemberBookmark(String memberId, int page, int pageSize) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+
+        List<Feed> entites = feedRepository.findByMemberBookmarkFeed(
+                Member.builder().memberId(memberId).build(), pageable
+        );
+
+        List<FeedSummaryDto> feedListByMemberBookmark = FeedSummaryDto.toDtoList(entites);
+
+        return feedListByMemberBookmark;
+    }
+
+    @Override
     public List<FeedSummaryDto> getFeedListByBuildingSubscription(String memberId) {
         List<Feed> entites = feedRepository.findByMemberBuildingSubscription(
                 Member.builder()
                         .memberId(memberId)
                         .build()
+        );
+
+        List<FeedSummaryDto> feedListByBuildingSubscription = FeedSummaryDto.toDtoList(entites);
+
+        return feedListByBuildingSubscription;
+    }
+
+    @Override
+    public List<FeedSummaryDto> getFeedListByBuildingSubscription(String memberId, int page, int pageSize) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+
+        List<Feed> entites = feedRepository.findByMemberBuildingSubscription(
+                Member.builder().memberId(memberId).build(), pageable
         );
 
         List<FeedSummaryDto> feedListByBuildingSubscription = FeedSummaryDto.toDtoList(entites);

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
@@ -164,7 +164,7 @@ public class FeedSubServiceImpl implements FeedSubService {
     @Override
     public int addFeedComment(FeedCommentDto feedCommentDto) {
         FeedComment addFeedComment = FeedCommentDto.toEntity(feedCommentDto);
-
+        addFeedComment.setActivated(true);
         return feedCommentRepository.save(addFeedComment).getCommentId();
     }
 

--- a/src/test/java/com/kube/noon/feed/service/TestFeedServiceImpl.java
+++ b/src/test/java/com/kube/noon/feed/service/TestFeedServiceImpl.java
@@ -42,35 +42,35 @@ public class TestFeedServiceImpl {
     @Transactional
     @Test
     public void getListTest() {
-        List<FeedSummaryDto> feedListByMember = feedServiceImpl.getFeedListByMember("member_1");
+        List<FeedSummaryDto> feedListByMember = feedServiceImpl.getFeedListByMember("member_1", 0, 10);
         assertThat(feedListByMember).isNotNull();
         assertThat(feedListByMember.size()).isGreaterThan(0);
         for (FeedSummaryDto feedSummaryDto : feedListByMember) {
             log.info(feedSummaryDto);
         }
 
-        List<FeedSummaryDto> feedListByBuilding = feedServiceImpl.getFeedListByBuilding("member_3", 10001);
+        List<FeedSummaryDto> feedListByBuilding = feedServiceImpl.getFeedListByBuilding("member_3", 10001, 0, 10);
         assertThat(feedListByBuilding).isNotNull();
         assertThat(feedListByBuilding.size()).isGreaterThan(0);
         for (FeedSummaryDto feedSummaryDto : feedListByBuilding) {
             log.info(feedSummaryDto);
         }
 
-        List<FeedSummaryDto> feedListByMemberLike = feedServiceImpl.getFeedListByMemberLike("member_1");
+        List<FeedSummaryDto> feedListByMemberLike = feedServiceImpl.getFeedListByMemberLike("member_1", 0, 10);
         assertThat(feedListByMemberLike).isNotNull();
         assertThat(feedListByMemberLike.size()).isGreaterThan(0);
         for (FeedSummaryDto feedSummaryDto : feedListByMemberLike) {
             log.info(feedSummaryDto);
         }
 
-        List<FeedSummaryDto> feedListByMemberBookmark = feedServiceImpl.getFeedListByMemberBookmark("member_1");
+        List<FeedSummaryDto> feedListByMemberBookmark = feedServiceImpl.getFeedListByMemberBookmark("member_1", 0, 10);
         assertThat(feedListByMemberBookmark).isNotNull();
         assertThat(feedListByMemberBookmark.size()).isGreaterThan(0);
         for (FeedSummaryDto feedSummaryDto : feedListByMemberBookmark) {
             log.info(feedSummaryDto);
         }
 
-        List<FeedSummaryDto> feedListByBuildingSubscription = feedServiceImpl.getFeedListByBuildingSubscription("member_1");
+        List<FeedSummaryDto> feedListByBuildingSubscription = feedServiceImpl.getFeedListByBuildingSubscription("member_1", 0, 10);
         assertThat(feedListByBuildingSubscription).isNotNull();
         assertThat(feedListByBuildingSubscription.size()).isGreaterThan(0);
         for (FeedSummaryDto feedSummaryDto : feedListByBuildingSubscription) {

--- a/src/test/java/com/kube/noon/feed/service/TestFeedServiceImpl.java
+++ b/src/test/java/com/kube/noon/feed/service/TestFeedServiceImpl.java
@@ -135,9 +135,7 @@ public class TestFeedServiceImpl {
     @Transactional
     @Test
     public void deleteFeedTest() {
-        FeedDto deleteFeed = feedServiceImpl.getFeedById(10000);
-
-        int feedId = feedServiceImpl.deleteFeed(deleteFeed);
+        int feedId = feedServiceImpl.deleteFeed(10000);
 
         // 지워진 피드는 Repository 내에서 확인 가능하다.
         Feed getFeed = feedRepository.findByFeedId(feedId);


### PR DESCRIPTION
## 요약
FeedController를 보완하는 과정을 거쳤습니다.

## 변경 사항 설명
- FeedController의 테스트를 `Postman`을 통해 진행하였습니다. 시간이 허락했다면 테스트 코드도 따로 짜고 싶었는데 거기까진 시간이 안될 거 같아서 임의로 테스트를 진행했습니다. 당연히 찾지 못한 버그가 있을 수 있으니 계속 주시하겠습니다.
- Controller를 구성할 때 Get Method 사용 시 쿼리스트링을, Post Method 사용 시 URI을 사용하여 데이터를 가져오게 했습니다. 혹시 표준에 맞지 않다면 바로 수정하겠습니다.
- 피드 목록을 가져올 때 `Pageable`을 통한 일부분만 가져오는 기능을 적용했습니다.
- `Swagger`(이 프로젝트에서는 `Springdoc` 사용)를 통해서 Controller를 간단하게 명세화했습니다. 사용할 때 참고하시면 좋을 거 같습니다. 

## 관련 이슈 및 참고 자료
#71 
이 PR 이후로 Client 쪽으로 넘어가서 작업하겠습니다.
