### PR TITLE
chore : matout-integreation dependency 삭제

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,12 +155,12 @@
             <artifactId>imageio-webp</artifactId>
             <version>3.9.4</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.apache.mahout/mahout-integration -->
-        <dependency>
-            <groupId>org.apache.mahout</groupId>
-            <artifactId>mahout-integration</artifactId>
-            <version>0.13.0</version>
-        </dependency>
+<!--        &lt;!&ndash; https://mvnrepository.com/artifact/org.apache.mahout/mahout-integration &ndash;&gt;-->
+<!--        <dependency>-->
+<!--            <groupId>org.apache.mahout</groupId>-->
+<!--            <artifactId>mahout-integration</artifactId>-->
+<!--            <version>0.13.0</version>-->
+<!--        </dependency>-->
         <!-- https://mvnrepository.com/artifact/org.apache.mahout/mahout-mr -->
         <dependency>
             <groupId>org.apache.mahout</groupId>


### PR DESCRIPTION
## 요약
배포 환경 에러를 막기 위한 dependency 삭제

## 변경 사항 설명
이거 없어도 잘 돌아가서 일단 PR 보냅니다.

## 관련 이슈 및 참고 자료
NULL
