### PR TITLE
feat : chatroomSearchService 및 adminRestController 추가 (24.6.12)

### DIFF
--- a/src/main/java/com/kube/noon/chat/controller/ChatroomAdminRestController.java
+++ b/src/main/java/com/kube/noon/chat/controller/ChatroomAdminRestController.java
@@ -1,8 +1,51 @@
 package com.kube.noon.chat.controller;
 
+import com.kube.noon.chat.dto.ChatroomDto;
+import com.kube.noon.chat.service.ChatroomSearchService;
+import com.kube.noon.chat.service.ChatroomService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
+@RequestMapping("/adminChatroom")
 public class ChatroomAdminRestController {
-    //드간다
+
+    private final ChatroomSearchService chatroomSearchService;
+    private final ChatroomService chatroomService;
+
+    @Autowired
+    public ChatroomAdminRestController(ChatroomSearchService chatroomSearchService, ChatroomService chatroomService) {
+        this.chatroomSearchService = chatroomSearchService;
+        this.chatroomService = chatroomService;
+    }
+
+    /**
+     * 채팅방 검색
+     * @param searchKeywordChatroomName
+     * @return
+     * @throws Exception
+     */
+    @GetMapping("chatroomSearch")
+    public List<ChatroomDto> chatroomSearch(String searchKeywordChatroomName) throws Exception {
+        List<ChatroomDto> chatrooms = chatroomSearchService.getChatroomListByChatroomName(searchKeywordChatroomName);
+
+        return chatrooms;
+    }
+
+    /**
+     * 채팅방 삭제
+     * @param chatroomId
+     * @return
+     * @throws Exception
+     */
+    @GetMapping("chatroomDelete")
+    public String chatroomDelete(int chatroomId) throws Exception {
+
+        return chatroomService.deleteChatroom(chatroomId);
+    }
+
 }

--- a/src/main/java/com/kube/noon/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/kube/noon/chat/repository/ChatroomRepository.java
@@ -3,7 +3,6 @@ package com.kube.noon.chat.repository;
 import com.kube.noon.chat.domain.Chatroom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.awt.print.Pageable;
 import java.util.List;
 
 public interface ChatroomRepository extends JpaRepository<Chatroom, Integer> {
@@ -12,5 +11,6 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Integer> {
     List<Chatroom> findByBuildingId(int buildingId);
     List<Chatroom> findByBuildingIdAndChatroomNameContaining(int buildingId, String searchKeywordChatroom);
     List<Chatroom> findByChatroomNameContaining(String searchKeywordChatroom);
-
+    void deleteChatroomByChatroomId(int chatroomId);
+    Chatroom findChatroomByChatroomId(int chatroomId);
 }

--- a/src/main/java/com/kube/noon/chat/service/ChatroomSearchService.java
+++ b/src/main/java/com/kube/noon/chat/service/ChatroomSearchService.java
@@ -43,5 +43,5 @@ public interface ChatroomSearchService {
      * @return
      * @throws Exception
      */
-    public List<ChatroomDto> getLivelistChatroomList() throws Exception;
+    public List<ChatroomDto> getLivelistChatroomList(int buildingId) throws Exception;
 }

--- a/src/main/java/com/kube/noon/chat/service/ChatroomService.java
+++ b/src/main/java/com/kube/noon/chat/service/ChatroomService.java
@@ -17,7 +17,11 @@ public interface ChatroomService {
 
     /**
      * 채팅방 삭제 (관리자 기능)
+     * @param chatroomId
+     * @return
+     * @throws Exception
      */
+    public String deleteChatroom(int chatroomId) throws Exception;
 
     /**
      * 채팅방에 참여한 멤버 리스트를 채팅방으로 조회

--- a/src/main/java/com/kube/noon/chat/serviceImpl/ChatroomSearchServiceImpl.java
+++ b/src/main/java/com/kube/noon/chat/serviceImpl/ChatroomSearchServiceImpl.java
@@ -36,7 +36,7 @@ public class ChatroomSearchServiceImpl implements ChatroomSearchService {
     public List<ChatroomDto> getBuildingChatroomListByChatroomName(int buildingId, String searchKeywordChatroom) throws Exception {
         List<Chatroom> chatrooms = chatroomRepository.findByBuildingIdAndChatroomNameContaining(buildingId, searchKeywordChatroom);
 
-        List<ChatroomDto> chatroomDtos = convertToChatroomDtoList(chatrooms);
+        List <ChatroomDto> chatroomDtos = convertToChatroomDtoList(chatrooms);
 
         return chatroomDtos;
     }
@@ -69,7 +69,7 @@ public class ChatroomSearchServiceImpl implements ChatroomSearchService {
     }
 
     @Override
-    public List<ChatroomDto> getLivelistChatroomList() throws Exception {
+    public List<ChatroomDto> getLivelistChatroomList(int buildingId) throws Exception {
         return null; // 구현 고민중
     }
 
@@ -89,4 +89,5 @@ public class ChatroomSearchServiceImpl implements ChatroomSearchService {
         dto.setChatroomType(chatroom.getChatroomType().toString()); // Enum 값을 문자열로 변환하여 설정
         return dto;
     }
+
 }

--- a/src/main/java/com/kube/noon/chat/serviceImpl/ChatroomServiceImpl.java
+++ b/src/main/java/com/kube/noon/chat/serviceImpl/ChatroomServiceImpl.java
@@ -53,6 +53,18 @@ public class ChatroomServiceImpl implements ChatroomService {
         return convertToChatroomDto(savedChatroom);
     }
 
+    @Override
+    public String deleteChatroom(int chatroomId) throws Exception {
+        // 채팅방 삭제
+        chatroomRepository.deleteChatroomByChatroomId(chatroomId);
+
+        Chatroom chatroom = chatroomRepository.findChatroomByChatroomId(chatroomId);
+        if(chatroom != null) {
+            System.out.println("        🦐[ServiceImpl] deleteChatroom 삭제 안됨 => " + chatroom);
+        }
+        return "delete success";
+    }
+
     // 채팅방 참여멤버를 채팅방으로 조회 (테스트위해 방 번호 고정해놓음)
     @Override
     public List<ChatEntranceDto> getChatEntranceListByChatroom(ChatroomDto requestChatroom) {

--- a/src/test/java/com/kube/noon/chat/ChatroomSearchServiceImplTest.java
+++ b/src/test/java/com/kube/noon/chat/ChatroomSearchServiceImplTest.java
@@ -1,105 +1,106 @@
-//package com.kube.noon.chat
-//import com.kube.noon.chat.domain.Chatroom;
-//import com.kube.noon.chat.domain.ChatroomType;
-//import com.kube.noon.chat.dto.ChatroomDto;
-//import com.kube.noon.chat.repository.ChatroomRepository;
-//import com.kube.noon.chat.service.ChatroomSearchService;
-//import com.kube.noon.chat.serviceImpl.ChatroomSearchServiceImpl;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.MockitoAnnotations;
-//
-//import java.util.Arrays;
-//import java.util.List;
-//import java.util.Optional;
-//
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.mockito.Mockito.when;
-//
-//public class ChatroomSearchServiceImplTest {
-//
-//    @Mock
-//    private ChatroomRepository chatroomRepository;
-//
-//    @InjectMocks
-//    private ChatroomSearchServiceImpl chatroomSearchService;
-//
-//    @BeforeEach
-//    public void setUp() {
-//        MockitoAnnotations.openMocks(this);
-//    }
-//
-//    @Test
-//    public void testGetBuildingChatroomList() throws Exception {
-//        int buildingId = 1;
-//        Chatroom chatroom1 = createChatroom(1, "creator1", buildingId, "Room1", ChatroomType.PUBLIC, true);
-//        Chatroom chatroom2 = createChatroom(2, "creator2", buildingId, "Room2", ChatroomType.PRIVATE, true);
-//
-//        when(chatroomRepository.findByBuildingId(buildingId)).thenReturn(Arrays.asList(chatroom1, chatroom2));
-//
-//        List<ChatroomDto> result = chatroomSearchService.getBuildingChatroomList(buildingId);
-//
-//        assertEquals(2, result.size());
-//        assertEquals("Room1", result.get(0).getChatroomName());
-//        assertEquals("Room2", result.get(1).getChatroomName());
-//    }
-//
-//    @Test
-//    public void testGetBuildingChatroomListByChatroomName() throws Exception {
-//        int buildingId = 1;
-//        String searchKeyword = "Room";
-//        Chatroom chatroom1 = createChatroom(1, "creator1", buildingId, "Room1", ChatroomType.PUBLIC, true);
-//        Chatroom chatroom2 = createChatroom(2, "creator2", buildingId, "Room2", ChatroomType.PRIVATE, true);
-//
-//        when(chatroomRepository.findByBuildingIdAndChatroomNameContaining(buildingId, searchKeyword)).thenReturn(Arrays.asList(chatroom1, chatroom2));
-//
-//        List<ChatroomDto> result = chatroomSearchService.getBuildingChatroomListByChatroomName(buildingId, searchKeyword);
-//
-//        assertEquals(2, result.size());
-//        assertEquals("Room1", result.get(0).getChatroomName());
-//        assertEquals("Room2", result.get(1).getChatroomName());
-//    }
-//
-//    @Test
-//    public void testGetChatroomListByChatroomName() throws Exception {
-//        String searchKeyword = "Room";
-//        Chatroom chatroom1 = createChatroom(1, "creator1", 1, "Room1", ChatroomType.PUBLIC, true);
-//        Chatroom chatroom2 = createChatroom(2, "creator2", 2, "Room2", ChatroomType.PRIVATE, true);
-//
-//        when(chatroomRepository.findByChatroomNameContaining(searchKeyword)).thenReturn(Arrays.asList(chatroom1, chatroom2));
-//
-//        List<ChatroomDto> result = chatroomSearchService.getChatroomListByChatroomName(searchKeyword);
-//
-//        assertEquals(2, result.size());
-//        assertEquals("Room1", result.get(0).getChatroomName());
-//        assertEquals("Room2", result.get(1).getChatroomName());
-//    }
-//
-//    @Test
-//    public void testGetLivelistChatroomList() throws Exception {
-//        int buildingId = 1;
-//        Chatroom chatroom1 = createChatroom(1, "creator1", buildingId, "Room1", ChatroomType.PUBLIC, true);
-//        Chatroom chatroom2 = createChatroom(2, "creator2", buildingId, "Room2", ChatroomType.PRIVATE, true);
-//
-////        when(chatroomRepository.findByBuildingIdAndActivatedTrue(buildingId)).thenReturn(Arrays.asList(chatroom1, chatroom2));
-//
-//        List<ChatroomDto> result = chatroomSearchService.getLivelistChatroomList(buildingId);
-//
-//        assertEquals(2, result.size());
-//        assertEquals("Room1", result.get(0).getChatroomName());
-//        assertEquals("Room2", result.get(1).getChatroomName());
-//    }
-//
-//    private Chatroom createChatroom(int id, String creatorId, int buildingId, String name, ChatroomType type, boolean activated) {
-//        Chatroom chatroom = new Chatroom();
-//        chatroom.setChatroomId(id);
-//        chatroom.setChatroomCreatorId(creatorId);
-//        chatroom.setBuildingId(buildingId);
-//        chatroom.setChatroomName(name);
-//        chatroom.setChatroomType(type);
-//        chatroom.setActivated(activated);
-//        return chatroom;
-//    }
-//}
+package com.kube.noon.chat;
+
+import com.kube.noon.chat.domain.Chatroom;
+import com.kube.noon.chat.domain.ChatroomType;
+import com.kube.noon.chat.dto.ChatroomDto;
+import com.kube.noon.chat.repository.ChatroomRepository;
+import com.kube.noon.chat.service.ChatroomSearchService;
+import com.kube.noon.chat.serviceImpl.ChatroomSearchServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class ChatroomSearchServiceImplTest {
+
+    @Mock
+    private ChatroomRepository chatroomRepository;
+
+    @InjectMocks
+    private ChatroomSearchServiceImpl chatroomSearchService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testGetBuildingChatroomList() throws Exception {
+        int buildingId = 1;
+        Chatroom chatroom1 = createChatroom(1, "creator1", buildingId, "Room1", ChatroomType.PRIVATE_CHATTING, true);
+        Chatroom chatroom2 = createChatroom(2, "creator2", buildingId, "Room2", ChatroomType.GROUP_CHATTING, true);
+
+        when(chatroomRepository.findByBuildingId(buildingId)).thenReturn(Arrays.asList(chatroom1, chatroom2));
+
+        List<ChatroomDto> result = chatroomSearchService.getBuildingChatroomList(buildingId);
+
+        assertEquals(2, result.size());
+        assertEquals("Room1", result.get(0).getChatroomName());
+        assertEquals("Room2", result.get(1).getChatroomName());
+    }
+
+    @Test
+    public void testGetBuildingChatroomListByChatroomName() throws Exception {
+        int buildingId = 1;
+        String searchKeyword = "Room";
+        Chatroom chatroom1 = createChatroom(1, "creator1", buildingId, "Room1", ChatroomType.GROUP_CHATTING, true);
+        Chatroom chatroom2 = createChatroom(2, "creator2", buildingId, "Room2", ChatroomType.PRIVATE_CHATTING, true);
+
+        when(chatroomRepository.findByBuildingIdAndChatroomNameContaining(buildingId, searchKeyword)).thenReturn(Arrays.asList(chatroom1, chatroom2));
+
+        List<ChatroomDto> result = chatroomSearchService.getBuildingChatroomListByChatroomName(buildingId, searchKeyword);
+
+        assertEquals(2, result.size());
+        assertEquals("Room1", result.get(0).getChatroomName());
+        assertEquals("Room2", result.get(1).getChatroomName());
+    }
+
+    @Test
+    public void testGetChatroomListByChatroomName() throws Exception {
+        String searchKeyword = "Ro";
+        Chatroom chatroom1 = createChatroom(1, "creator1", 1, "Room1", ChatroomType.GROUP_CHATTING, true);
+        Chatroom chatroom2 = createChatroom(2, "creator2", 2, "Room2", ChatroomType.PRIVATE_CHATTING, true);
+
+        when(chatroomRepository.findByChatroomNameContaining(searchKeyword)).thenReturn(Arrays.asList(chatroom1, chatroom2));
+
+        List<ChatroomDto> result = chatroomSearchService.getChatroomListByChatroomName(searchKeyword);
+
+        assertEquals(2, result.size());
+        assertEquals("Room1", result.get(0).getChatroomName());
+        assertEquals("Room2", result.get(1).getChatroomName());
+    }
+
+    @Test
+    public void testGetLivelistChatroomList() throws Exception {
+        int buildingId = 1;
+        Chatroom chatroom1 = createChatroom(1, "creator1", buildingId, "Room1", ChatroomType.GROUP_CHATTING, true);
+        Chatroom chatroom2 = createChatroom(2, "creator2", buildingId, "Room2", ChatroomType.PRIVATE_CHATTING, true);
+
+//        when(chatroomRepository.findByBuildingIdAndActivatedTrue(buildingId)).thenReturn(Arrays.asList(chatroom1, chatroom2));
+
+        List<ChatroomDto> result = chatroomSearchService.getLivelistChatroomList(buildingId);
+
+        assertEquals(2, result.size());
+        assertEquals("Room1", result.get(0).getChatroomName());
+        assertEquals("Room2", result.get(1).getChatroomName());
+    }
+
+    private Chatroom createChatroom(int id, String creatorId, int buildingId, String name, ChatroomType type, boolean activated) {
+        Chatroom chatroom = new Chatroom();
+        chatroom.setChatroomId(id);
+        chatroom.setChatroomCreatorId(creatorId);
+        chatroom.setBuildingId(buildingId);
+        chatroom.setChatroomName(name);
+        chatroom.setChatroomType(type);
+        chatroom.setActivated(activated);
+        return chatroom;
+    }
+}


### PR DESCRIPTION
## 요약
(pull request 내용의 요약을 1~2줄로 요약해서 작성합니다)

## 변경 사항 설명
- chat/service/ChatroomSearchService 에 건물별 채팅방 목록 조회, 건물별 채팅방목록 검색 등의 메소드 추가하였습니다
- chat/controller/ChatroomAdminRestController 에 관리자 기능 (전체 채팅방 검색 및 삭제) 추가 하였습니다
- repository, impl 테스트 시작

## 관련 이슈 및 참고 자료

cf. 리뷰반영 사항
도엽 - bulider 패턴 아직x
경도 - Sl4J, javadoc 넣는중