### PR TITLE
refactor : 피드 내부 로직 관련 수정 사항

### DIFF
--- a/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
+++ b/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
@@ -86,8 +86,8 @@ public class FeedRestController {
 
     @Operation(summary = "피드 수정", description = "피드를 하나 수정합니다. 제목과 텍스트, 카테고리만 수정 가능합니다.")
     @PostMapping("/updateFeed")
-    public int updateFeed(@RequestBody FeedDto feedDto) {
-        int feedId = feedService.updateFeed(feedDto);
+    public int updateFeed(@RequestBody UpdateFeedDto updateFeedDto) {
+        int feedId = feedService.updateFeed(updateFeedDto);
 
         return feedId;
     }

--- a/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
+++ b/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
@@ -221,7 +221,7 @@ public class FeedRestController {
     }
 
     @Operation(summary = "피드 내 태그 목록 조회", description = "피드에 등록된 태그 목록을 가져옵니다.")
-    @GetMapping("/feedTagList")
+    @GetMapping("/getFeedTagList")
     public List<TagDto> getFeedTagList(@Parameter(description = "피드 목록을 가져올 피드 ID") @RequestParam int feedId) {
         return feedSubService.getFeedTagList(feedId);
     }

--- a/src/main/java/com/kube/noon/feed/dto/FeedDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedDto.java
@@ -39,6 +39,7 @@ public class FeedDto {
     private boolean activate;
     private List<FeedAttachmentDto> attachments;
     private List<FeedCommentDto> comments;
+    private List<TagDto> tags;
     private List<TagFeedDto> tagFeeds;
 
     public static FeedDto toDto(Feed feed) {

--- a/src/main/java/com/kube/noon/feed/dto/FeedDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedDto.java
@@ -41,6 +41,7 @@ public class FeedDto {
     private List<FeedCommentDto> comments;
     private List<TagDto> tags;
     private List<TagFeedDto> tagFeeds;
+    private List<String> updateTagList; // 피드를 추가할 때 피드 내용을 가져올 리스트
 
     public static FeedDto toDto(Feed feed) {
         // NullPointException

--- a/src/main/java/com/kube/noon/feed/dto/FeedSummaryDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedSummaryDto.java
@@ -3,6 +3,7 @@ package com.kube.noon.feed.dto;
 import com.kube.noon.feed.domain.Feed;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,6 +21,7 @@ public class FeedSummaryDto {
     private String feedText;
     private int buildingId;
     private String buildingName;
+    private LocalDateTime writtenTime;
     private String feedAttachementURL;
 
     public static FeedSummaryDto toDto(Feed feed) {
@@ -31,6 +33,7 @@ public class FeedSummaryDto {
                 .feedText(feed.getFeedText())
                 .buildingId(feed.getBuilding().getBuildingId())
                 .buildingName(feed.getBuilding().getBuildingName())
+                .writtenTime(feed.getWrittenTime())
                 .feedAttachementURL((feed.getAttachments() == null || feed.getAttachments().size() == 0) ? null : feed.getAttachments().get(0).getFileUrl())
                 .build();
     }

--- a/src/main/java/com/kube/noon/feed/dto/FeedSummaryDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedSummaryDto.java
@@ -30,6 +30,7 @@ public class FeedSummaryDto {
                 .title(feed.getTitle())
                 .feedText(feed.getFeedText())
                 .buildingId(feed.getBuilding().getBuildingId())
+                .buildingName(feed.getBuilding().getBuildingName())
                 .feedAttachementURL((feed.getAttachments() == null || feed.getAttachments().size() == 0) ? null : feed.getAttachments().get(0).getFileUrl())
                 .build();
     }

--- a/src/main/java/com/kube/noon/feed/dto/UpdateFeedDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/UpdateFeedDto.java
@@ -1,0 +1,26 @@
+package com.kube.noon.feed.dto;
+
+import com.kube.noon.common.FeedCategory;
+import com.kube.noon.common.PublicRange;
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * 피드가 수정될 때 사용하는 Dto이다.
+ * 정해진 데이터만 수정 가능하도록 한다.
+ */
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class UpdateFeedDto {
+    private int feedId;
+    private String feedText;
+    private String title;
+    private PublicRange publicRange;
+    private FeedCategory feedCategory;
+    private List<String> updateTagList; // 피드를 수정할 때 태그 리스트를 가져올 리스트
+}

--- a/src/main/java/com/kube/noon/feed/repository/TagFeedRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/TagFeedRepository.java
@@ -4,6 +4,11 @@ import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.feed.domain.Tag;
 import com.kube.noon.feed.domain.TagFeed;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 
 public interface TagFeedRepository extends JpaRepository<TagFeed, Long> {
@@ -13,4 +18,14 @@ public interface TagFeedRepository extends JpaRepository<TagFeed, Long> {
      * @return
      */
      int deleteByTagAndFeed(Tag tag, Feed feed);
+
+    /**
+     * 피드 번호에 속하는 연관 테이블의 모든 태그를 삭제한다.
+     * 피드가 추가되거나 수정될 때 사용한다.
+     * @param feed feedId가 담긴 객체를 받는다.
+     * @return
+     */
+    @Modifying
+    @Query("DELETE FROM TagFeed tf WHERE tf.feed.feedId = :#{#feed.feedId}")
+    int deleteByFeed(@Param("feed") Feed feed);
 }

--- a/src/main/java/com/kube/noon/feed/service/FeedService.java
+++ b/src/main/java/com/kube/noon/feed/service/FeedService.java
@@ -2,6 +2,7 @@ package com.kube.noon.feed.service;
 
 import com.kube.noon.feed.dto.FeedDto;
 import com.kube.noon.feed.dto.FeedSummaryDto;
+import com.kube.noon.feed.dto.UpdateFeedDto;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -41,7 +42,7 @@ public interface FeedService {
     int addFeed(FeedDto feedDto);
 
     // 피드를 수정한다.
-    int updateFeed(FeedDto feedDto);
+    int updateFeed(UpdateFeedDto updateFeedDto);
 
     // 피드를 삭제한다.
     int deleteFeed(int feedId);

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
@@ -4,16 +4,20 @@ import com.kube.noon.building.domain.Building;
 import com.kube.noon.common.FeedCategory;
 import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.feed.domain.Tag;
+import com.kube.noon.feed.domain.TagFeed;
 import com.kube.noon.feed.dto.FeedDto;
 import com.kube.noon.feed.dto.FeedSummaryDto;
 import com.kube.noon.feed.dto.TagDto;
+import com.kube.noon.feed.dto.UpdateFeedDto;
 import com.kube.noon.feed.repository.FeedRepository;
+import com.kube.noon.feed.repository.TagFeedRepository;
 import com.kube.noon.feed.repository.TagRepository;
 import com.kube.noon.feed.repository.mybatis.FeedMyBatisRepository;
 import com.kube.noon.feed.service.FeedService;
-import com.kube.noon.feed.service.FeedSubService;
 import com.kube.noon.feed.service.recommend.FeedRecommendationMemberId;
 import com.kube.noon.member.domain.Member;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.PageRequest;
@@ -33,6 +37,10 @@ public class FeedServiceImpl implements FeedService {
     private final FeedRepository feedRepository;
     private final FeedMyBatisRepository feedMyBatisRepository;
     private final TagRepository tagRepository;
+    private final TagFeedRepository tagFeedRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     @Override
     public List<FeedSummaryDto> getFeedListByMember(String memberId) {
@@ -215,22 +223,87 @@ public class FeedServiceImpl implements FeedService {
             addFeed.setBuilding(null);
         }
         addFeed.setActivated(true);
-        return feedRepository.save(addFeed).getFeedId();
+
+        int feedId = feedRepository.save(addFeed).getFeedId();
+
+        List<String> updateTagList = feedDto.getUpdateTagList();
+
+        // 태그는 각각 리스트를 받아서 추가한다.
+        if(updateTagList != null && updateTagList.size() > 0) {
+            for(String tagText : updateTagList) {
+                // 1. 삽입 전 tag 테이블에 존재하는지 탐색
+                Tag tag = tagRepository.findByTagText(tagText);
+
+                // 1-1. 만약 테이블에 없다면 삽입하기
+                if(tag == null) {
+                    tag = Tag.builder().tagText(tagText).build();
+                    tag = tagRepository.save(tag);
+                }
+
+                // 2. tag_feed 테이블에 추가하기
+                Feed feed = Feed.builder().feedId(feedId).build();
+                TagFeed tagFeed = TagFeed.builder().feed(feed).tag(tag).build();
+
+                tagFeedRepository.save(tagFeed);
+            }
+        }
+
+        entityManager.flush();
+        entityManager.clear();
+
+        return feedId;
     }
 
     @Transactional
     @Override
-    public int updateFeed(FeedDto feedDto) {
-        Feed updateFeed = feedRepository.findByFeedId(feedDto.getFeedId());
+    public int updateFeed(UpdateFeedDto updateFeedDto) {
+        int feedId = updateFeedDto.getFeedId();
+        Feed updateFeed = feedRepository.findByFeedId(updateFeedDto.getFeedId());
 
         if(updateFeed.getFeedCategory() == FeedCategory.NOTICE) {
             updateFeed.setBuilding(null);
         }
-        updateFeed.setTitle(feedDto.getTitle());
-        updateFeed.setFeedText(feedDto.getFeedText());
+        // 수정 가능한 내용 : 제목, 내용, 공개범위, 카테고리
+        updateFeed.setTitle(updateFeedDto.getTitle());
+        updateFeed.setFeedText(updateFeedDto.getFeedText());
         updateFeed.setModified(true);
-        updateFeed.setFeedCategory(feedDto.getFeedCategory());
-        return feedRepository.save(updateFeed).getFeedId();
+        updateFeed.setPublicRange(updateFeedDto.getPublicRange());
+        updateFeed.setFeedCategory(updateFeedDto.getFeedCategory());
+
+        List<String> updateTagList = updateFeedDto.getUpdateTagList();
+
+        // feed 내용 업데이트
+        int updateFeedId = feedRepository.save(updateFeed).getFeedId();
+
+        // 피드의 태그 정리
+        // 0. 피드에 속한 모든 태그 삭제 -> 중복 태그 대비
+        tagFeedRepository.deleteByFeed(updateFeed);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        if(updateTagList != null && updateTagList.size() > 0) {
+            for(String tagText : updateTagList) {
+                // 1. 삽입 전 tag 테이블에 존재하는지 탐색
+                Tag tag = tagRepository.findByTagText(tagText);
+
+                // 1-1. 만약 테이블에 없다면 삽입하기
+                if(tag == null) {
+                    tag = Tag.builder().tagText(tagText).build();
+                    tag = tagRepository.save(tag);
+                }
+
+                System.out.println(tag.getTagId());
+
+                // 2. tag_feed 테이블에 추가하기
+                Feed feed = Feed.builder().feedId(feedId).build();
+                TagFeed tagFeed = TagFeed.builder().feed(feed).tag(tag).build();
+
+                tagFeedRepository.save(tagFeed);
+            }
+        }
+
+        return updateFeedId;
     }
 
     @Transactional

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
@@ -3,11 +3,15 @@ package com.kube.noon.feed.service.impl;
 import com.kube.noon.building.domain.Building;
 import com.kube.noon.common.FeedCategory;
 import com.kube.noon.feed.domain.Feed;
+import com.kube.noon.feed.domain.Tag;
 import com.kube.noon.feed.dto.FeedDto;
 import com.kube.noon.feed.dto.FeedSummaryDto;
+import com.kube.noon.feed.dto.TagDto;
 import com.kube.noon.feed.repository.FeedRepository;
+import com.kube.noon.feed.repository.TagRepository;
 import com.kube.noon.feed.repository.mybatis.FeedMyBatisRepository;
 import com.kube.noon.feed.service.FeedService;
+import com.kube.noon.feed.service.FeedSubService;
 import com.kube.noon.feed.service.recommend.FeedRecommendationMemberId;
 import com.kube.noon.member.domain.Member;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +32,7 @@ public class FeedServiceImpl implements FeedService {
 
     private final FeedRepository feedRepository;
     private final FeedMyBatisRepository feedMyBatisRepository;
+    private final TagRepository tagRepository;
 
     @Override
     public List<FeedSummaryDto> getFeedListByMember(String memberId) {
@@ -240,7 +245,13 @@ public class FeedServiceImpl implements FeedService {
     @Override
     public FeedDto getFeedById(int feedId) {
         Feed getFeed = feedRepository.findByFeedId(feedId);
-        return FeedDto.toDto(getFeed);
+        FeedDto resultFeed = FeedDto.toDto(getFeed);
+
+        // tag의 목록을 가져온다.
+        List<Tag> tagList = tagRepository.getTagByFeedId(Feed.builder().feedId(feedId).build());
+        resultFeed.setTags(TagDto.toDtoList(tagList));
+
+        return resultFeed;
     }
 
     @Transactional

--- a/src/test/java/com/kube/noon/feed/service/TestFeedServiceImpl.java
+++ b/src/test/java/com/kube/noon/feed/service/TestFeedServiceImpl.java
@@ -3,8 +3,10 @@ package com.kube.noon.feed.service;
 import com.kube.noon.common.FeedCategory;
 import com.kube.noon.common.PublicRange;
 import com.kube.noon.feed.domain.Feed;
+import com.kube.noon.feed.domain.TagFeed;
 import com.kube.noon.feed.dto.FeedDto;
 import com.kube.noon.feed.dto.FeedSummaryDto;
+import com.kube.noon.feed.dto.UpdateFeedDto;
 import com.kube.noon.feed.repository.FeedRepository;
 import com.kube.noon.feed.service.impl.FeedServiceImpl;
 import com.kube.noon.feed.service.impl.FeedStatisticsServiceImpl;
@@ -17,6 +19,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -86,6 +89,12 @@ public class TestFeedServiceImpl {
     @Transactional
     @Test
     public void addFeedTest() {
+        // 태그 추가
+        List<String> updateTagList = new ArrayList<>();
+        updateTagList.add("집에");
+        updateTagList.add("가고");
+        updateTagList.add("싶다");
+
         FeedDto feedDto = FeedDto.builder()
                 .writerId("member_15")
                 .buildingId(10015)
@@ -97,16 +106,21 @@ public class TestFeedServiceImpl {
                 .writtenTime(LocalDateTime.now())
                 .feedCategory(FeedCategory.GENERAL)
                 .modified(false)
+                .updateTagList(updateTagList)
                 .build();
 
         int feedId = feedServiceImpl.addFeed(feedDto);
 
         FeedDto getFeedDto = feedServiceImpl.getFeedById(feedId);
 
+        log.info(getFeedDto);
+
         assertThat(getFeedDto).isNotNull();
         assertThat(getFeedDto.getWriterId()).isEqualTo("member_15");
         assertThat(getFeedDto.getBuildingId()).isEqualTo(10015);
         assertThat(getFeedDto.getTitle()).isEqualTo("WinterHana Test");
+        assertThat(getFeedDto.getTagFeeds().size()).isEqualTo(3);
+        assertThat(getFeedDto.getTags().size()).isEqualTo(3);
     }
 
     /**
@@ -115,18 +129,34 @@ public class TestFeedServiceImpl {
     @Transactional
     @Test
     public void updateFeedTest() {
-        FeedDto updateFeedDto = feedServiceImpl.getFeedById(10000);
-        updateFeedDto.setFeedText("수정 테스트 중입니다.");
+        List<String> updateTagList = new ArrayList<>();
+        updateTagList.add("집에");
+        updateTagList.add("가고");
+        updateTagList.add("싶다");
+
+        FeedDto feedDto = feedServiceImpl.getFeedById(10000);
+        UpdateFeedDto updateFeedDto = UpdateFeedDto.builder()
+                .feedId(feedDto.getFeedId())
+                .feedText("수정 테스트 중입니다.")
+                .title(feedDto.getTitle())
+                .publicRange(feedDto.getPublicRange())
+                .feedCategory(feedDto.getFeedCategory())
+                .updateTagList(updateTagList)
+                .build();
 
         int feedId = feedServiceImpl.updateFeed(updateFeedDto);
 
         FeedDto getFeedDto = feedServiceImpl.getFeedById(feedId);
+
+        log.info(getFeedDto);
 
         assertThat(getFeedDto).isNotNull();
         assertThat(getFeedDto.getWriterId()).isEqualTo("member_1");
         assertThat(getFeedDto.getBuildingId()).isEqualTo(10001);
         assertThat(getFeedDto.getTitle()).isEqualTo("Title_1");
         assertThat(getFeedDto.getFeedText()).isEqualTo("수정 테스트 중입니다.");
+        assertThat(getFeedDto.getTagFeeds().size()).isEqualTo(3);
+        assertThat(getFeedDto.getTags().size()).isEqualTo(3);
     }
 
     /**


### PR DESCRIPTION
## 요약
Clinet View를 제작하면서 Server 로직 중 필요한 수정을 정리했습니다.

## 변경 사항 설명
- 데이터가 일부 누락됐던 버그(또는 놓친 점)을 수정했습니다
    - FeedList에 `작성 날짜`, `건물 이름`
- 태그와 관련하여 개선점이 있었습니다.
    - 피드 상세보기를 가져올 때 하나의 서비스 내에서 바로 태그 내용을 가지고 올 수 있도록 하였습니다.
    - 피드 추가, 수정 시 태그까지 한 번에 저장할 수 있도록 로직을 수정했습니다.
    - `updateFeedDto`를 추가하여 필요한 정보만 수정할 수 있도록 수정했습니다.

## 관련 이슈 및 참고 자료
#99 
위 이슈는 삭제하지 않고 수정 사항이 생길 때마다 계속 수정할 예정입니다.
