### PR TITLE
fix: UpdateMemberDto에서 Nickname이 null일 때 검증하지 않음

### DIFF
--- a/src/main/java/com/kube/noon/member/validator/MemberValidationRule.java
+++ b/src/main/java/com/kube/noon/member/validator/MemberValidationRule.java
@@ -76,8 +76,10 @@ public class MemberValidationRule {
         validationChain.addRule(UpdateMemberDto.class, dto -> {
             memberScanner.imoTwoDataNotNullSimul(dto.getMemberId(), dto.getNickname());
             memberScanner.imoNotBadWord(dto.getMemberId());
-            memberScanner.imoNotBadWord(dto.getNickname());
 
+            if (dto.getNickname() != null) {
+                memberScanner.imoNotBadWord(dto.getNickname());
+            }
             if (dto.getMemberId() != null) {
                 memberScanner.imoMemberIdPatternO(dto.getMemberId());
             }


### PR DESCRIPTION
## 요약
UpdateMemberDto에서 nickname이 null일 경우 검증하지 않도록 변경

## 변경 사항 설명
- Nickname이 null이라는 것은 nickname을 변경하지 않겠다는 것을 의미한다. 그러므로 nullable이다.

## 관련 이슈 및 참고 자료
Issue: #121
