### PR TITLE
refactor: 좌표를 파라미터로 건물 프로필 받아올 때 응답 케이스 추가

### DIFF
--- a/src/main/java/com/kube/noon/building/controller/BuildingProfileRestController.java
+++ b/src/main/java/com/kube/noon/building/controller/BuildingProfileRestController.java
@@ -2,6 +2,7 @@
 
 package com.kube.noon.building.controller;
 import com.kube.noon.building.dto.BuildingDto;
+import com.kube.noon.building.dto.BuildingNotFoundResponseDto;
 import com.kube.noon.building.dto.BuildingSearchResponseDto;
 import com.kube.noon.building.dto.BuildingZzimDto;
 import com.kube.noon.building.service.BuildingProfileService;
@@ -19,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @RestController
 @RequestMapping("/buildingProfile")
@@ -101,7 +103,15 @@ public class BuildingProfileRestController {
             BuildingDto resp = this.buildingProfileService.getBuildingProfileByPosition(position);
             return new ResponseEntity<>(resp, HttpStatus.OK);
         } catch (PlaceNotFoundException e) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            return new ResponseEntity<>(
+                    new BuildingNotFoundResponseDto(false, "해당 좌표에 건물이 없음"),
+                    HttpStatus.NOT_FOUND
+            );
+        } catch (NoSuchElementException e) {
+            return new ResponseEntity<>(
+                    new BuildingNotFoundResponseDto(true,"등록되지 않은 건물"),
+                    HttpStatus.NOT_FOUND
+            );
         }
     }
 

--- a/src/main/java/com/kube/noon/building/dto/BuildingNotFoundResponseDto.java
+++ b/src/main/java/com/kube/noon/building/dto/BuildingNotFoundResponseDto.java
@@ -1,0 +1,11 @@
+package com.kube.noon.building.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@Getter
+@ToString
+public class BuildingNotFoundResponseDto {
+    private final boolean buildingExisting;
+    private final String message;
+}

--- a/src/main/java/com/kube/noon/building/service/BuildingProfileServiceImpl.java
+++ b/src/main/java/com/kube/noon/building/service/BuildingProfileServiceImpl.java
@@ -25,10 +25,7 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.data.web.config.SortHandlerMethodArgumentResolverCustomizer;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 
@@ -176,11 +173,12 @@ public class BuildingProfileServiceImpl implements BuildingProfileService {
     }
 
     @Override
-    public BuildingDto getBuildingProfileByPosition(Position position) throws PlaceNotFoundException {
+    public BuildingDto getBuildingProfileByPosition(Position position)
+            throws PlaceNotFoundException, NoSuchElementException {
         PlaceDto findPlace = this.placesService.getPlaceByPosition(position);
         Building building = this.buildingProfileRepository.findBuildingProfileByRoadAddr(findPlace.getRoadAddress());
         if (building == null) {
-            throw new PlaceNotFoundException("No building");
+            throw new NoSuchElementException("No building");
         }
         return BuildingDto.fromEntity(building);
     }


### PR DESCRIPTION
## 요약
해당 좌표에 건물이 없을 때/해당 좌표에 건물은 있으나 등록된 건물이 아닐 때
각각 경우에 해당하는 응답이 있어야 함

## 변경 사항 설명
### 해당 좌표에 건물이 없을 경우
![image](https://github.com/kuberMAPtes/noon-main-api-server/assets/60085941/1871db2c-de9d-4c74-8889-95ee3db3c14e)

### 해당 좌표에 건물은 있으나 등록된 건물이 아닐 경우
![image](https://github.com/kuberMAPtes/noon-main-api-server/assets/60085941/746a06c8-b2bf-47a1-9db5-a0f5b98b62c1)


## 관련 이슈 및 참고 자료
Issue: #154
