### PR TITLE
refactor : 사진 / 동영상 사진을 가져오기 위한 데이터 수정

### DIFF
--- a/src/main/java/com/kube/noon/common/ObjectStorageAPI.java
+++ b/src/main/java/com/kube/noon/common/ObjectStorageAPI.java
@@ -67,12 +67,24 @@ public class ObjectStorageAPI {
         return fileUrl;
     }
 
-    // getFeedAttachment
+    // getFeedAttachment : 정해진 파일이 없다면 null로 처리한다.
     public S3ObjectInputStream getObject(String fileName) {
-        S3Object s3Object = s3.getObject(BUCKET_NAME, fileName);
+        try {
+            S3Object s3Object = s3.getObject(BUCKET_NAME, fileName);
+            S3ObjectInputStream s3ObjectInputStream = s3Object.getObjectContent();
+            return s3ObjectInputStream;
+        } catch (AmazonS3Exception e) {
+            if(e.getStatusCode() == 404) {
+                System.err.println("File not found");
+            } else {
+                System.err.println("Amazon S3 Error : " + e.getMessage());
+            }
 
-        S3ObjectInputStream s3ObjectInputStream = s3Object.getObjectContent();
+            return null;
+        } catch (Exception e) {
+            System.err.println("Exception : " + e.getMessage());
+            return null;
+        }
 
-        return s3ObjectInputStream;
     }
 }

--- a/src/main/java/com/kube/noon/feed/dto/FeedAttachmentDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedAttachmentDto.java
@@ -23,6 +23,8 @@ public class FeedAttachmentDto {
     private boolean activated;
 
     public static FeedAttachmentDto toDto(FeedAttachment feedAttachment) {
+        if(feedAttachment == null) return null;
+
         return FeedAttachmentDto.builder()
                 .attachmentId(feedAttachment.getAttachmentId())
                 .feedId(feedAttachment.getFeed().getFeedId())

--- a/src/main/java/com/kube/noon/feed/dto/FeedSummaryDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedSummaryDto.java
@@ -1,6 +1,7 @@
 package com.kube.noon.feed.dto;
 
 import com.kube.noon.feed.domain.Feed;
+import com.kube.noon.feed.domain.FeedAttachment;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -22,12 +23,27 @@ public class FeedSummaryDto {
     private int buildingId;
     private String buildingName;
     private LocalDateTime writtenTime;
-    private String feedAttachementURL;
+    private int feedAttachmentId;
     private boolean like;
     private boolean bookmark;
     private boolean mainActivated;
 
     public static FeedSummaryDto toDto(Feed feed) {
+        
+        // 유효한 첨부파일 걸러내기
+        List<FeedAttachment> attachments = null;
+        if (feed.getAttachments() != null && feed.getAttachments().size() > 0) {
+            attachments = feed.getAttachments().stream()
+                    .filter(s -> s.isActivated() == true)
+                    .collect(Collectors.toList());
+
+            for(FeedAttachment attachment : attachments) {
+                System.out.println(attachment);
+            }
+        }
+
+
+
         return FeedSummaryDto.builder()
                 .feedId(feed.getFeedId())
                 .writerId(feed.getWriter().getMemberId())
@@ -38,7 +54,7 @@ public class FeedSummaryDto {
                 .buildingName(feed.getBuilding().getBuildingName())
                 .writtenTime(feed.getWrittenTime())
                 .mainActivated(feed.isMainActivated())
-                .feedAttachementURL((feed.getAttachments() == null || feed.getAttachments().size() == 0) ? null : feed.getAttachments().get(0).getFileUrl())
+                .feedAttachmentId((attachments == null || attachments.isEmpty()) ? 0 : attachments.get(0).getAttachmentId())
                 .build();
     }
 

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
@@ -52,10 +52,21 @@ public class FeedSubServiceImpl implements FeedSubService {
     public ResponseEntity<byte[]> getFeedAttachment(int attachmentId) {
         FeedAttachmentDto feedAttachmentDto = FeedAttachmentDto.toDto(feedAttachmentRepository.findByAttachmentId(attachmentId));
 
+        if (feedAttachmentDto == null) {
+            // return new ResponseEntity<>(HttpStatus.NOT_FOUND); // 찾을 수 없음을 확인(404)
+            return null;
+        }
+
         String[] fileNames = feedAttachmentDto.getFileUrl().split("/");
         String fileName = fileNames[fileNames.length - 1];
 
+
         S3ObjectInputStream inputStream = objectStorageAPI.getObject(fileName);
+
+        if (inputStream == null) {
+            // return new ResponseEntity<>(HttpStatus.NOT_FOUND); // 찾을 수 없음을 확인(404)
+            return null;
+        }
 
         try {
             byte[] imageBytes = inputStream.readAllBytes();

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
@@ -71,12 +71,30 @@ public class FeedSubServiceImpl implements FeedSubService {
         try {
             byte[] imageBytes = inputStream.readAllBytes();
             HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(MediaType.IMAGE_JPEG);
+
+            MediaType mediaType = getMediaType(fileName);
+            headers.setContentType(mediaType);
 
             return new ResponseEntity<>(imageBytes, headers, HttpStatus.OK);
         } catch(IOException e) {
             e.printStackTrace();
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // 파일 확장자를 기반으로 MIME 타입을 반환하는 메소드
+    private MediaType getMediaType(String fileName) {
+        String[] parts = fileName.split("\\.");
+        String extension = parts[parts.length - 1].toLowerCase(); // 파일 확장자를 소문자로 변환하여 비교
+
+        switch (extension) {
+            case "jpg": case "jpeg":
+            case "png": case "gif":
+                return MediaType.IMAGE_JPEG; // 이미지 파일인 경우
+            case "mp4":
+                return MediaType.valueOf("video/mp4"); // 동영상 파일인 경우
+            default:
+                return MediaType.APPLICATION_OCTET_STREAM; // 기타 파일은 바이너리 스트림으로 처리
         }
     }
 


### PR DESCRIPTION
## 요약
사진과 동영상을 가져오는 과정에서 데이터를 수정하였습니다.

## 변경 사항 설명
- 첨부파일을 가져오기 위해 로직을 크게 변경하였는데, 이 과정은 다음과 같습니다.
1. 데이터가 없을 때 null 처리 -> 클라이언트 쪽에서 이를 처리합니다.

2. 파일 확장자를 기반으로 MIME 타입을 반환 -> 이 파일이 사진인지 동영상인지 파악합니다.

3. 대략적으로 attachmentId를 통해 첨부파일을 하나씩 가져오는 방식이라고 생각하시면 됩니다. 즉, 한 번에 가져오는 등의 개선의 여지가 있으나 일단 구현부터 하는게 좋을 거 같아 이 방향으로 구현하였습니다. 

## 관련 이슈 및 참고 자료
없음