### PR TITLE
feat : 투표 게시판 구현을 위한 로직 추가

### DIFF
--- a/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
+++ b/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
@@ -315,7 +315,7 @@ public class FeedRestController {
 
     @Operation(summary = "[투표] 투표 내용 삭제", description = "투표 내용을 삭제한다.")
     @PostMapping("/deleteVote/{feedId}")
-    public int deleteFeedVotes(@Parameter(description = "삭제할 피드 ID") int feedId) {
+    public int deleteFeedVotes(@Parameter(description = "삭제할 피드 ID") @PathVariable("feedId") int feedId) {
         feedVotesService.deleteVote(feedId);
 
         return feedId;
@@ -324,8 +324,8 @@ public class FeedRestController {
     @Operation(summary = "[투표] 특정 투표 내용에 투표하기", description = "실제로 투표에 참여한다.")
     @PostMapping("/addVoting/{feedId}/{optionIndex}")
     public int addVoting(
-            @Parameter(description = "참여할 투표에 대한 피드 ID") int feedId,
-            @Parameter(description = "옵션의 번호") int optionIndex) {
+            @Parameter(description = "참여할 투표에 대한 피드 ID") @PathVariable("feedId") int feedId,
+            @Parameter(description = "옵션의 번호") @PathVariable("optionIndex") int optionIndex) {
         feedVotesService.addVoting(feedId, optionIndex);
 
         return feedId;
@@ -334,8 +334,8 @@ public class FeedRestController {
     @Operation(summary = "[투표] 특정 투표 취소하기", description = "투표를 취소한다.")
     @PostMapping("/deleteVoting/{feedId}/{optionIndex}")
     public int deleteVoting(
-            @Parameter(description = "취소할 투표에 대한 피드 ID") int feedId,
-            @Parameter(description = "옵션의 번호") int optionIndex) {
+            @Parameter(description = "취소할 투표에 대한 피드 ID") @PathVariable("feedId") int feedId,
+            @Parameter(description = "옵션의 번호") @PathVariable("optionIndex") int optionIndex) {
         feedVotesService.deleteVoting(feedId, optionIndex);
 
         return feedId;
@@ -344,7 +344,7 @@ public class FeedRestController {
     @Operation(summary = "[투표] 투표 내용 가져오기", description = "투표를 취소한다.")
     @GetMapping("/getVote/{feedId}")
     public FeedVotesDto getVote(
-            @Parameter(description = "가져올 피드 ID") int feedId) {
+            @Parameter(description = "가져올 피드 ID") @PathVariable("feedId") int feedId) {
         return feedVotesService.getVoteById(feedId);
     }
 }

--- a/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
+++ b/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
@@ -4,6 +4,7 @@ import com.kube.noon.feed.dto.*;
 import com.kube.noon.feed.service.FeedService;
 import com.kube.noon.feed.service.FeedStatisticsService;
 import com.kube.noon.feed.service.FeedSubService;
+import com.kube.noon.feed.service.FeedVotesService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,6 +25,7 @@ public class FeedRestController {
     private final FeedService feedService;
     private final FeedStatisticsService feedStatisticsService;
     private final FeedSubService feedSubService;
+    private final FeedVotesService feedVotesService;
 
     private static final int PAGE_SIZE = 10;        // 일단 static final로 설정, 나중에 메타데이터로 뺄 예정
 
@@ -297,5 +299,52 @@ public class FeedRestController {
     @GetMapping("/FeedPopularity")
     public List<FeedPopularityDto> getFeedPopularity(@RequestParam int buildingId) {
         return feedStatisticsService.getFeedPopularity(buildingId);
+    }
+
+    @Operation(summary = "[투표] 투표 게시판 생성", description = "투표 게시판을 생성한다.")
+    @PostMapping("/addVote")
+    public FeedVotesDto addVote(@RequestBody FeedVotesDto feedVotesDto) {
+        return feedVotesService.addVote(feedVotesDto);
+    }
+
+    @Operation(summary = "[투표] 투표 게시판 갱신", description = "투표 게시판을 생성한다.")
+    @PostMapping("/updateVote")
+    public FeedVotesDto updateFeedVotes(@RequestBody FeedVotesDto feedVotesDto) {
+        return feedVotesService.updateVote(feedVotesDto);
+    }
+
+    @Operation(summary = "[투표] 투표 내용 삭제", description = "투표 내용을 삭제한다.")
+    @PostMapping("/deleteVote/{feedId}")
+    public int deleteFeedVotes(@Parameter(description = "삭제할 피드 ID") int feedId) {
+        feedVotesService.deleteVote(feedId);
+
+        return feedId;
+    }
+
+    @Operation(summary = "[투표] 특정 투표 내용에 투표하기", description = "실제로 투표에 참여한다.")
+    @PostMapping("/addVoting/{feedId}/{optionIndex}")
+    public int addVoting(
+            @Parameter(description = "참여할 투표에 대한 피드 ID") int feedId,
+            @Parameter(description = "옵션의 번호") int optionIndex) {
+        feedVotesService.addVoting(feedId, optionIndex);
+
+        return feedId;
+    }
+
+    @Operation(summary = "[투표] 특정 투표 취소하기", description = "투표를 취소한다.")
+    @PostMapping("/deleteVoting/{feedId}/{optionIndex}")
+    public int deleteVoting(
+            @Parameter(description = "취소할 투표에 대한 피드 ID") int feedId,
+            @Parameter(description = "옵션의 번호") int optionIndex) {
+        feedVotesService.deleteVoting(feedId, optionIndex);
+
+        return feedId;
+    }
+
+    @Operation(summary = "[투표] 투표 내용 가져오기", description = "투표를 취소한다.")
+    @GetMapping("/getVote/{feedId}")
+    public FeedVotesDto getVote(
+            @Parameter(description = "가져올 피드 ID") int feedId) {
+        return feedVotesService.getVoteById(feedId);
     }
 }

--- a/src/main/java/com/kube/noon/feed/domain/FeedVotes.java
+++ b/src/main/java/com/kube/noon/feed/domain/FeedVotes.java
@@ -1,0 +1,32 @@
+package com.kube.noon.feed.domain;
+
+import com.kube.noon.feed.domain.converter.ListToStringConverter;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "feed_votes")
+public class FeedVotes {
+    @Id
+    private int feedId;
+
+    private String question;
+
+    @Convert(converter = ListToStringConverter.class)
+    private List<String> options;
+
+    @Convert(converter = ListToStringConverter.class)
+    private List<Integer> votes;
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "feed_id")
+    private Feed feed;
+}

--- a/src/main/java/com/kube/noon/feed/domain/FeedVotes.java
+++ b/src/main/java/com/kube/noon/feed/domain/FeedVotes.java
@@ -1,5 +1,6 @@
 package com.kube.noon.feed.domain;
 
+import com.kube.noon.feed.domain.converter.ListToIntegerConverter;
 import com.kube.noon.feed.domain.converter.ListToStringConverter;
 import jakarta.persistence.*;
 import lombok.*;
@@ -22,7 +23,7 @@ public class FeedVotes {
     @Convert(converter = ListToStringConverter.class)
     private List<String> options;
 
-    @Convert(converter = ListToStringConverter.class)
+    @Convert(converter = ListToIntegerConverter.class)
     private List<Integer> votes;
 
     @OneToOne

--- a/src/main/java/com/kube/noon/feed/domain/converter/ListToIntegerConverter.java
+++ b/src/main/java/com/kube/noon/feed/domain/converter/ListToIntegerConverter.java
@@ -1,0 +1,33 @@
+package com.kube.noon.feed.domain.converter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Converter
+public class ListToIntegerConverter implements AttributeConverter<List<Integer>, String> {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<Integer> attribute) {
+        try {
+            return mapper.writeValueAsString(attribute);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("정수 리스트를 JSON으로 변환하는 중 오류 발생", e);
+        }
+    }
+
+    @Override
+    public List<Integer> convertToEntityAttribute(String dbData) {
+        try {
+            return mapper.readValue(dbData, new TypeReference<List<Integer>>() {});
+        } catch (IOException e) {
+            throw new IllegalArgumentException("JSON을 정수 리스트로 변환하는 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/kube/noon/feed/domain/converter/ListToStringConverter.java
+++ b/src/main/java/com/kube/noon/feed/domain/converter/ListToStringConverter.java
@@ -1,0 +1,35 @@
+package com.kube.noon.feed.domain.converter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Converter
+public class ListToStringConverter implements AttributeConverter<List<String>, String> {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    // database 값으로 변경
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        try {
+            return mapper.writeValueAsString(attribute);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Error converting list to JSON", e);
+        }
+    }
+
+    // Entity 값으로 변경
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        try {
+            return mapper.readValue(dbData, new TypeReference<List<String>>() {});
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Error converting JSON to list", e);
+        }
+    }
+}

--- a/src/main/java/com/kube/noon/feed/dto/FeedSummaryDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedSummaryDto.java
@@ -1,5 +1,6 @@
 package com.kube.noon.feed.dto;
 
+import com.kube.noon.common.FeedCategory;
 import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.feed.domain.FeedAttachment;
 import lombok.*;
@@ -24,6 +25,7 @@ public class FeedSummaryDto {
     private String buildingName;
     private LocalDateTime writtenTime;
     private int feedAttachmentId;
+    private FeedCategory feedCategory;
     private boolean like;
     private boolean bookmark;
     private boolean mainActivated;
@@ -42,8 +44,6 @@ public class FeedSummaryDto {
             }
         }
 
-
-
         return FeedSummaryDto.builder()
                 .feedId(feed.getFeedId())
                 .writerId(feed.getWriter().getMemberId())
@@ -53,6 +53,7 @@ public class FeedSummaryDto {
                 .buildingId(feed.getBuilding().getBuildingId())
                 .buildingName(feed.getBuilding().getBuildingName())
                 .writtenTime(feed.getWrittenTime())
+                .feedCategory(feed.getFeedCategory())
                 .mainActivated(feed.isMainActivated())
                 .feedAttachmentId((attachments == null || attachments.isEmpty()) ? 0 : attachments.get(0).getAttachmentId())
                 .build();

--- a/src/main/java/com/kube/noon/feed/dto/FeedVotesDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedVotesDto.java
@@ -14,9 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 @Getter
 @Setter
-@ToString
 public class FeedVotesDto {
-    private Feed feed;
     private int feedId;
     private String question;
     private List<String> options;
@@ -24,7 +22,6 @@ public class FeedVotesDto {
 
     public static FeedVotesDto toDto(FeedVotes feedVotes) {
         return FeedVotesDto.builder()
-                .feed(feedVotes.getFeed())
                 .feedId(feedVotes.getFeedId())
                 .question(feedVotes.getQuestion())
                 .options(feedVotes.getOptions())
@@ -32,4 +29,11 @@ public class FeedVotesDto {
                 .build();
     }
 
+    @Override
+    public String toString() {
+        return "feedId : " + feedId +
+                ", question : " + question +
+                ", options : " + options +
+                ", votes : " + votes;
+    }
 }

--- a/src/main/java/com/kube/noon/feed/dto/FeedVotesDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedVotesDto.java
@@ -1,0 +1,35 @@
+package com.kube.noon.feed.dto;
+
+import com.kube.noon.feed.domain.Feed;
+import com.kube.noon.feed.domain.FeedVotes;
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * 투표 정보를 가져오기 위한 Dto
+ */
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class FeedVotesDto {
+    private Feed feed;
+    private int feedId;
+    private String question;
+    private List<String> options;
+    private List<Integer> votes;
+
+    public static FeedVotesDto toDto(FeedVotes feedVotes) {
+        return FeedVotesDto.builder()
+                .feed(feedVotes.getFeed())
+                .feedId(feedVotes.getFeedId())
+                .question(feedVotes.getQuestion())
+                .options(feedVotes.getOptions())
+                .votes(feedVotes.getVotes())
+                .build();
+    }
+
+}

--- a/src/main/java/com/kube/noon/feed/repository/FeedVotesRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/FeedVotesRepository.java
@@ -1,0 +1,9 @@
+package com.kube.noon.feed.repository;
+
+import com.kube.noon.feed.domain.Feed;
+import com.kube.noon.feed.domain.FeedVotes;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedVotesRepository extends JpaRepository<FeedVotes, Integer>  {
+    // blank
+}

--- a/src/main/java/com/kube/noon/feed/service/FeedVotesService.java
+++ b/src/main/java/com/kube/noon/feed/service/FeedVotesService.java
@@ -1,0 +1,26 @@
+package com.kube.noon.feed.service;
+
+import com.kube.noon.feed.domain.FeedVotes;
+import com.kube.noon.feed.dto.FeedVotesDto;
+
+import java.util.List;
+
+public interface FeedVotesService {
+    // 투표를 생성한다.
+    FeedVotesDto addVote(FeedVotesDto feedVotesDto);
+
+    // 투표를 수정한다.
+    FeedVotesDto updateVote(FeedVotesDto feedVotesDto);
+
+    // 투표를 삭제한다.
+    void deleteVote(int feedId);
+
+    // 투표에 참여한다.
+    void addVoting(int feedId, int optionIndex);
+
+    // 투표 참여를 취소한다.
+    void deleteVoting(int feedId, int optionIndex);
+
+    // 특정 투표를 조회한다.
+    FeedVotesDto getVoteById(int feedId);
+}

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedVotesServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedVotesServiceImpl.java
@@ -1,0 +1,84 @@
+package com.kube.noon.feed.service.impl;
+
+import com.kube.noon.feed.domain.Feed;
+import com.kube.noon.feed.domain.FeedVotes;
+import com.kube.noon.feed.dto.FeedVotesDto;
+import com.kube.noon.feed.repository.FeedRepository;
+import com.kube.noon.feed.repository.FeedVotesRepository;
+import com.kube.noon.feed.service.FeedVotesService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class FeedVotesServiceImpl implements FeedVotesService {
+
+    private final FeedVotesRepository feedVotesRepository;
+    private final FeedRepository feedRepository;
+
+    @Transactional
+    @Override
+    public FeedVotesDto addVote(FeedVotesDto feedVotesDto) {
+        Feed feed = feedRepository.findByFeedId(feedVotesDto.getFeedId());
+        FeedVotes feedVotes = FeedVotes.builder()
+                .feed(feed)
+                .question(feedVotesDto.getQuestion())
+                .options(feedVotesDto.getOptions())
+                .votes(new ArrayList<>(Collections.nCopies(feedVotesDto.getOptions().size(), 0))) // 0으로 초기화
+                .build();
+
+        return FeedVotesDto.toDto(feedVotesRepository.save(feedVotes));
+    }
+
+    @Transactional
+    @Override
+    public FeedVotesDto updateVote(FeedVotesDto feedVotesDto) {
+        FeedVotes feedVotes = feedVotesRepository.findById(feedVotesDto.getFeedId()).orElseThrow(() -> new IllegalArgumentException("유효한 ID가 아님"));
+        feedVotes.setQuestion(feedVotesDto.getQuestion());
+        feedVotes.setOptions(feedVotesDto.getOptions());
+        feedVotes.setVotes(new ArrayList<>(Collections.nCopies(feedVotesDto.getOptions().size(), 0))); // ㅊ기화
+
+        return FeedVotesDto.toDto(feedVotesRepository.save(feedVotes));
+    }
+
+    @Transactional
+    @Override
+    public void deleteVote(int feedId) {
+        feedVotesRepository.deleteById(feedId);
+    }
+
+    @Transactional
+    @Override
+    public void addVoting(int feedId, int optionIndex) {
+        FeedVotes feedVotes = feedVotesRepository.findById(feedId).orElseThrow(() -> new IllegalArgumentException("Invalid feed ID"));
+        List<Integer> votes = feedVotes.getVotes();
+        votes.set(optionIndex, votes.get(optionIndex) + 1);
+        feedVotes.setVotes(votes);
+        feedVotesRepository.save(feedVotes);
+    }
+
+    @Override
+    public void deleteVoting(int feedId, int optionIndex) {
+        FeedVotes feedVotes = feedVotesRepository.findById(feedId).orElseThrow(() -> new IllegalArgumentException("Invalid feed ID"));
+        List<Integer> votes = feedVotes.getVotes();
+        votes.set(optionIndex, votes.get(optionIndex) - 1);
+        feedVotes.setVotes(votes);
+        feedVotesRepository.save(feedVotes);
+    }
+
+
+    @Override
+    public FeedVotesDto getVoteById(int feedId) {
+        return FeedVotesDto.toDto(
+                feedVotesRepository.findById(feedId)
+                        .orElseThrow(() -> new IllegalArgumentException("유효한 ID가 아님"))
+        );
+    }
+}


### PR DESCRIPTION
## 요약
투표 게시판을 만들기 위한 기본 내용을 작성했습니다. 필요에 따라 더 구현할 수 있습니다.

## 변경 사항 설명
기본적인 투표 로직에 대하여 작성하였습니다.  
물론 빠진 부분이 있기 때문에 (예시 : 멤버별로 한 번씩 투표하게 하기) 현재 더 추가할 여지가 많습니다.

구현 과정에서 작은 table이 추가되었는데, 이는 다음과 같습니다.
```
# feed_votes
CREATE TABLE feed_votes (
	feed_id INT PRIMARY KEY,
    question VARCHAR(255) NOT NULL,
    options JSON NOT NULL,
    votes JSON NOT NULL,
    FOREIGN KEY (feed_id) REFERENCES feed(feed_id)
);
```
후에 구현이 완료되면 클라우드 DB에 테이블만 하나 추가하면 될 거 같습니다.

## 관련 이슈 및 참고 자료
없음
