### PR TITLE
fix : 투표 관련 작업 중 요구사항 변경 및 기타 버그 해결

### DIFF
--- a/src/main/java/com/kube/noon/common/zzim/ZzimRepository.java
+++ b/src/main/java/com/kube/noon/common/zzim/ZzimRepository.java
@@ -75,7 +75,7 @@ public interface ZzimRepository extends JpaRepository<Zzim, Integer> {
      * @param zzimType
      * @return Zzim 해당하는 Zzim 하나를 가져온다.
      */
-    Zzim findByFeedIdAndMemberIdAndZzimType(int feedId, String memberId, ZzimType zzimType);
+    List<Zzim> findByFeedIdAndMemberIdAndZzimTypeOrderByZzimId(int feedId, String memberId, ZzimType zzimType);
 
     /**
      * 회원 아이디와 찜 타입을 통해 회원의 좋아요, 북마크 여부를 확인한다.

--- a/src/main/java/com/kube/noon/feed/dto/FeedVotesDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedVotesDto.java
@@ -21,6 +21,8 @@ public class FeedVotesDto {
     private List<Integer> votes;
 
     public static FeedVotesDto toDto(FeedVotes feedVotes) {
+        if(feedVotes == null) return new FeedVotesDto(); // null 처리
+
         return FeedVotesDto.builder()
                 .feedId(feedVotes.getFeedId())
                 .question(feedVotes.getQuestion())

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
@@ -4,9 +4,7 @@ import com.kube.noon.building.domain.Building;
 import com.kube.noon.common.FeedCategory;
 import com.kube.noon.common.zzim.ZzimRepository;
 import com.kube.noon.common.zzim.ZzimType;
-import com.kube.noon.feed.domain.Feed;
-import com.kube.noon.feed.domain.Tag;
-import com.kube.noon.feed.domain.TagFeed;
+import com.kube.noon.feed.domain.*;
 import com.kube.noon.feed.dto.FeedDto;
 import com.kube.noon.feed.dto.FeedSummaryDto;
 import com.kube.noon.feed.dto.TagDto;
@@ -28,8 +26,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.ArrayList;;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -366,8 +363,19 @@ public class FeedServiceImpl implements FeedService {
     @Override
     public int deleteFeed(int feedId) {
         Feed deleteFeed = feedRepository.findByFeedId(feedId);
-
         deleteFeed.setActivated(false);
+
+        // 첨부 파일 삭제 : activated = false
+        for(FeedAttachment feedAttachment : deleteFeed.getAttachments()) {
+            feedAttachment.setActivated(false);
+        }
+
+        // 댓글 삭제 : activated = false
+        for(FeedComment feedComment : deleteFeed.getComments()) {
+            feedComment.setActivated(false);
+        }
+
+
         return feedRepository.save(deleteFeed).getFeedId();
     }
 

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
@@ -149,7 +149,8 @@ public class FeedSubServiceImpl implements FeedSubService {
     @Override
     public int addFeedLike(int feedId, String memberId) {
         // 1) 좋아요 데이터가 있는지 확인한다.
-        Zzim zzimLike = zzimRepository.findByFeedIdAndMemberIdAndZzimType(feedId, memberId, ZzimType.LIKE);
+        List<Zzim> zzimLikeList = zzimRepository.findByFeedIdAndMemberIdAndZzimTypeOrderByZzimId(feedId, memberId, ZzimType.LIKE);
+        Zzim zzimLike = (zzimLikeList.isEmpty() ? null : zzimLikeList.get(0)); // null로 데이터가 존재하는지 아닌지 확인, 중복 데이터 대비하여 List 중 하나를 가지고 옴
         Feed feed = feedRepository.findByFeedId(feedId);
         Zzim resultZzim;
 
@@ -174,7 +175,8 @@ public class FeedSubServiceImpl implements FeedSubService {
     @Transactional
     @Override
     public int deleteFeedLike(int feedId, String memberId) {
-        Zzim deleteZzim = zzimRepository.findByFeedIdAndMemberIdAndZzimType(feedId, memberId, ZzimType.LIKE);
+        List<Zzim> zzimLikeList = zzimRepository.findByFeedIdAndMemberIdAndZzimTypeOrderByZzimId(feedId, memberId, ZzimType.LIKE);
+        Zzim deleteZzim = (zzimLikeList.isEmpty() ? null : zzimLikeList.get(0));
 
         if(deleteZzim != null) {
             deleteZzim.setActivated(false);
@@ -188,11 +190,12 @@ public class FeedSubServiceImpl implements FeedSubService {
     @Override
     public int addFeedBookmark(int feedId, String memberId) {
         // 1) 북마크 데이터가 있는지 확인한다.
-        Zzim zzimLike = zzimRepository.findByFeedIdAndMemberIdAndZzimType(feedId, memberId, ZzimType.BOOKMARK);
+        List<Zzim> zzimBookmarkList = zzimRepository.findByFeedIdAndMemberIdAndZzimTypeOrderByZzimId(feedId, memberId, ZzimType.BOOKMARK);
+        Zzim zzimBookmark = (zzimBookmarkList.isEmpty() ? null : zzimBookmarkList.get(0));
         Feed feed = feedRepository.findByFeedId(feedId);
         Zzim resultZzim;
 
-        if(zzimLike == null) { // 2) 없다면, 하나 추가한다.
+        if(zzimBookmark == null) { // 2) 없다면, 하나 추가한다.
             Zzim newZzimBookmark = Zzim.builder()
                     .memberId(memberId)
                     .feedId(feedId)
@@ -203,8 +206,8 @@ public class FeedSubServiceImpl implements FeedSubService {
                     .build();
             resultZzim = zzimRepository.save(newZzimBookmark);
         } else { // 3) 있다면. activated = true로 설정한다.
-            zzimLike.setActivated(true);
-            resultZzim = zzimRepository.save(zzimLike);
+            zzimBookmark.setActivated(true);
+            resultZzim = zzimRepository.save(zzimBookmark);
         }
 
         return resultZzim.getZzimId();
@@ -213,7 +216,8 @@ public class FeedSubServiceImpl implements FeedSubService {
     @Transactional
     @Override
     public int deleteFeedBookmark(int feedId, String memberId) {
-        Zzim deleteZzim = zzimRepository.findByFeedIdAndMemberIdAndZzimType(feedId, memberId, ZzimType.BOOKMARK);
+        List<Zzim> zzimBookmarkList = zzimRepository.findByFeedIdAndMemberIdAndZzimTypeOrderByZzimId(feedId, memberId, ZzimType.BOOKMARK);
+        Zzim deleteZzim = (zzimBookmarkList.isEmpty() ? null : zzimBookmarkList.get(0));
 
         if(deleteZzim != null) {
             deleteZzim.setActivated(false);

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedVotesServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedVotesServiceImpl.java
@@ -78,7 +78,7 @@ public class FeedVotesServiceImpl implements FeedVotesService {
     public FeedVotesDto getVoteById(int feedId) {
         return FeedVotesDto.toDto(
                 feedVotesRepository.findById(feedId)
-                        .orElseThrow(() -> new IllegalArgumentException("유효한 ID가 아님"))
+                        .orElse(null)
         );
     }
 }

--- a/src/test/java/com/kube/noon/feed/repository/TestFeedRepository.java
+++ b/src/test/java/com/kube/noon/feed/repository/TestFeedRepository.java
@@ -287,7 +287,8 @@ public class TestFeedRepository {
 
         // 1. 추가
         // 1) 좋아요 데이터가 있는지 확인한다.
-        Zzim zzimLike = zzimRepository.findByFeedIdAndMemberIdAndZzimType(feedId, memberId, ZzimType.LIKE);
+        List<Zzim> zzimLikeList = zzimRepository.findByFeedIdAndMemberIdAndZzimTypeOrderByZzimId(feedId, memberId, ZzimType.LIKE);
+        Zzim zzimLike = (zzimLikeList.isEmpty() ? null : zzimLikeList.get(0));
         Zzim resultZzim;
 
         if(zzimLike == null) { // 2) 없다면, 하나 추가한다.
@@ -310,7 +311,8 @@ public class TestFeedRepository {
         log.info(resultZzim.toString());
 
         // 2. 삭제
-        Zzim deleteZzim = zzimRepository.findByFeedIdAndMemberIdAndZzimType(feedId, memberId, ZzimType.LIKE);
+        List<Zzim> zzimDeleteLikeList = zzimRepository.findByFeedIdAndMemberIdAndZzimTypeOrderByZzimId(feedId, memberId, ZzimType.LIKE);
+        Zzim deleteZzim = (zzimDeleteLikeList.isEmpty() ? null : zzimDeleteLikeList.get(0));
         deleteZzim.setActivated(false);
         resultZzim = zzimRepository.save(deleteZzim);
 
@@ -331,7 +333,8 @@ public class TestFeedRepository {
 
         // 1. 추가
         // 1) 북마크 데이터가 있는지 확인한다.
-        Zzim zzimBookmark = zzimRepository.findByFeedIdAndMemberIdAndZzimType(feedId, memberId, ZzimType.BOOKMARK);
+        List<Zzim> zzimBookmarkList = zzimRepository.findByFeedIdAndMemberIdAndZzimTypeOrderByZzimId(feedId, memberId, ZzimType.BOOKMARK);
+        Zzim zzimBookmark = (zzimBookmarkList.isEmpty() ? null : zzimBookmarkList.get(0));
         Zzim resultZzim;
 
         if(zzimBookmark == null) { // 2) 없다면, 하나 추가한다.
@@ -354,7 +357,8 @@ public class TestFeedRepository {
         log.info(resultZzim.toString());
 
         // 2. 삭제
-        Zzim deleteZzim = zzimRepository.findByFeedIdAndMemberIdAndZzimType(feedId, memberId, ZzimType.BOOKMARK);
+        List<Zzim> zzimDeleteBookmarkList = zzimRepository.findByFeedIdAndMemberIdAndZzimTypeOrderByZzimId(feedId, memberId, ZzimType.BOOKMARK);
+        Zzim deleteZzim = (zzimDeleteBookmarkList.isEmpty() ? null : zzimDeleteBookmarkList.get(0));
         deleteZzim.setActivated(false);
         resultZzim = zzimRepository.save(deleteZzim);
 

--- a/src/test/java/com/kube/noon/feed/service/TestFeedServiceImpl.java
+++ b/src/test/java/com/kube/noon/feed/service/TestFeedServiceImpl.java
@@ -208,6 +208,9 @@ public class TestFeedServiceImpl {
 
         assertThat(getFeed).isNotNull();
         assertThat(getFeed.isActivated()).isFalse();
+
+        assertThat(getFeed.getAttachments().stream().filter(s -> s.isActivated() == true)).size().isEqualTo(0);
+        assertThat(getFeed.getComments().stream().filter(s -> s.isActivated() == true)).size().isEqualTo(0);
     }
 
     /**


### PR DESCRIPTION
## 요약
Client 관련 작업 중 발생한 버그나 요구사항을 처리했습니다.

## 변경 사항 설명
### 1. 피드 비활성(삭제) 시 다른 연관 테이블의 데이터도 비활성화
첨부파일(FeedAttachment), 댓글(FeedComment)에 대한 비활성화도 같이 진행하도록 수정하였습니다.

### 2. 좋아요, 북마크 관련 버그 완화
비동기적으로 이뤄지는 작업 중 좋아요 신청 요청이 2번씩 들어가면 이와 관련된 버그가 발생하였습니다. 이를 좀 더 방어할 수 있도록 List 관련 로직으로 처리하였습니다.  
"완화" 라는 표현을 사용한 이유는 완벽한 해결책은 아니기 때문입니다. 다른 경우의 버그가 발생하면 다시 수정할 예정입니다.

### 3. FeedVotesDto 관련 처리
투표 화면을 만드는 중 null을 전달하는게 필요해져서 Exception 대신 null을 전달하도록 수정했습니다. null 관련 로직은 Client에서 처리합니다.

## 관련 이슈 및 참고 자료
없음
