### PR TITLE
feat : 프로필 사진 버킷 생성 및 분리

### DIFF
--- a/src/main/java/com/kube/noon/common/ObjectStorageAPIProfile.java
+++ b/src/main/java/com/kube/noon/common/ObjectStorageAPIProfile.java
@@ -1,0 +1,93 @@
+package com.kube.noon.common;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * ObjectStorageAPI와 BUCKET_NAME만 동일함
+ */
+@Component
+public class ObjectStorageAPIProfile {
+
+    private String BUCKET_NAME = "noon-storage-bucket-profile"; // hard-coding
+
+    private String ACCESS_KEY;
+
+    private String SECRET_KEY;
+
+    private static final String REGION_NAME = "kr-standard";
+
+    private static final String ENDPOINT = "https://kr.object.ncloudstorage.com";
+
+    private AmazonS3 s3;
+
+    public ObjectStorageAPIProfile(
+            // @Value("${objectstorage.bucket-name-profile}") String bucketName,
+            @Value("${objectstorage.access-key}") String accessKey,
+            @Value("${objectstorage.secret-key}") String secretKey
+    ) {
+        this.BUCKET_NAME = BUCKET_NAME;
+        this.ACCESS_KEY = accessKey;
+        this.SECRET_KEY = secretKey;
+
+        s3 = AmazonS3ClientBuilder.standard()
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(ENDPOINT, REGION_NAME))
+                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(ACCESS_KEY, SECRET_KEY)))
+                .build();
+    }
+
+    // 버킷 파일 URL 생성
+    public String getBucketFileUrl(String key) {
+        String fileUrl = s3.getUrl(BUCKET_NAME, key).toString();
+
+        return fileUrl;
+    }
+
+    // MultipartFile putObject
+    public String putObject(String objectName, MultipartFile multipartFile) throws Exception {
+        String fileUrl = getBucketFileUrl(objectName);
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(multipartFile.getContentType());
+        objectMetadata.setContentLength(multipartFile.getSize());
+        PutObjectRequest putObjectRequest = new PutObjectRequest(BUCKET_NAME, objectName,multipartFile.getInputStream(), objectMetadata);
+
+        try {
+            s3.putObject(putObjectRequest);
+        } catch (AmazonS3Exception e) {
+            e.printStackTrace();
+        } catch(SdkClientException e) {
+            e.printStackTrace();
+        }
+
+        return fileUrl;
+    }
+
+    // getFeedAttachment : 정해진 파일이 없다면 null로 처리한다.
+    public S3ObjectInputStream getObject(String fileName) {
+        try {
+            S3Object s3Object = s3.getObject(BUCKET_NAME, fileName);
+            S3ObjectInputStream s3ObjectInputStream = s3Object.getObjectContent();
+            return s3ObjectInputStream;
+        } catch (AmazonS3Exception e) {
+            if(e.getStatusCode() == 404) {
+                System.err.println("File not found");
+            } else {
+                System.err.println("Amazon S3 Error : " + e.getMessage());
+            }
+
+            return null;
+        } catch (Exception e) {
+            System.err.println("Exception : " + e.getMessage());
+            return null;
+        }
+
+    }
+}

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
@@ -3,6 +3,7 @@ package com.kube.noon.feed.service.impl;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.kube.noon.common.FileType;
 import com.kube.noon.common.ObjectStorageAPI;
+import com.kube.noon.common.ObjectStorageAPIProfile;
 import com.kube.noon.common.zzim.Zzim;
 import com.kube.noon.common.zzim.ZzimRepository;
 import com.kube.noon.common.zzim.ZzimType;
@@ -39,7 +40,7 @@ public class FeedSubServiceImpl implements FeedSubService {
     private final TagRepository tagRepository;
     private final ZzimRepository zzimRepository;
     private final ObjectStorageAPI objectStorageAPI;
-
+    private final ObjectStorageAPIProfile objectStorageAPIProfile; // test
 
     @Override
     public List<FeedAttachmentDto> getFeedAttachementListByFileType(FileType fileType) {
@@ -117,6 +118,7 @@ public class FeedSubServiceImpl implements FeedSubService {
 
                     // Object Storage에 넣기
                     String Url = objectStorageAPI.putObject(originalFileName, file);
+                    // String Url = objectStorageAPIProfile.putObject(originalFileName, file); // test
 
                     // DB에 넣기
                     feedAttachmentRepository.save(FeedAttachment.builder()


### PR DESCRIPTION
## 요약
프로필 사진을 저장하기 위한 버킷을 따로 생성하고 연동했습니다.

## 변경 사항 설명
- Object Storage의 프로필 사진용 버킷을 따로 생성하고 이를 연동하는 API code를 복사하여 분리하였습니다.
- Hard-coding된 부분은 바로 실사용을 하기 위해 조치한 것이며, 이에 따른 key 분리가 필요합니다.

## 관련 이슈 및 참고 자료
없음
