### PR TITLE
feat : 채팅방 폭파 +@

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,12 @@
             <version>0.13.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.nimbusds/nimbus-jose-jwt -->
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-quartz</artifactId>
+            <version>LATEST</version>
+        </dependency>
+        <!--   스케쥴링을 위한 의존성   -->
     </dependencies>
 
     <build>

--- a/src/main/java/com/kube/noon/chat/controller/ChatMatchingRestController.java
+++ b/src/main/java/com/kube/noon/chat/controller/ChatMatchingRestController.java
@@ -55,7 +55,7 @@ public class ChatMatchingRestController {
         // 1:1 채팅방을 생성하고 입장도 시킨다.
         ChatroomDto privateRoomDto = new ChatroomDto();
         privateRoomDto.setChatroomCreatorId(chatApplyDto.getFromId());
-        privateRoomDto.setChatroomType("PRIVATE_CHATTING");
+        privateRoomDto.setChatroomType(ChatroomType.PRIVATE_CHATTING);
         privateRoomDto.setChatroomName("사적채팅방 이름을 어떻게 하지 상대에 따라 유동적으로 가야될텐데");
         privateRoomDto.setChatroomMinTemp(0F);
         privateRoomDto.setInvitedMemberId(chatApplyDto.getToId());

--- a/src/main/java/com/kube/noon/chat/controller/ChatroomAdminRestController.java
+++ b/src/main/java/com/kube/noon/chat/controller/ChatroomAdminRestController.java
@@ -3,11 +3,20 @@ package com.kube.noon.chat.controller;
 import com.kube.noon.chat.dto.ChatroomDto;
 import com.kube.noon.chat.service.ChatroomSearchService;
 import com.kube.noon.chat.service.ChatroomService;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerKey;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.List;
 
 @RestController
@@ -48,4 +57,28 @@ public class ChatroomAdminRestController {
         return chatroomService.deleteChatroom(chatroomId);
     }
 
+    /**
+     * 의존성 Quartz 의 schedular 함수를 통 채팅방 자동삭제 시간을 반환
+     * @return
+     */
+    @Autowired
+    private Scheduler scheduler;
+
+    @GetMapping("/chatroomDeleteTime")
+    public long getNextTriggerTime() {
+        try {
+            /**
+             * TriggerKey를 통해 Quartz Scheduler에 등록된 특정 트리거를 식별하고 가져올 수 있다.
+             * TriggerKey는 트리거의 이름과 그룹을 가지고 식별한다. (TriggerKey의 두번째 인자가 그룹임. 현재는 그룹은 없음 DEFAULT로 세팅됨)
+             */
+            Trigger trigger = scheduler.getTrigger(new TriggerKey("deleteChatRoomsTrigger"));
+            if (trigger != null) {
+                Date nextFireTime = trigger.getNextFireTime(); // 다음 트리거 실행시간
+                return nextFireTime.getTime() - System.currentTimeMillis(); // 남은 시간 (= 다음 트리거 실행시간 - 현재시간)
+            }
+        } catch (SchedulerException e) {
+            e.printStackTrace();
+        }
+        return -1;
+    }
 }

--- a/src/main/java/com/kube/noon/chat/controller/ChatroomRestController.java
+++ b/src/main/java/com/kube/noon/chat/controller/ChatroomRestController.java
@@ -76,7 +76,17 @@ public class ChatroomRestController {
     public List<ChatroomDto> getChatrooms(@RequestParam("memberId") String memberId) throws Exception {
         System.out.println("        🐬[Controller] (memberId) => " + memberId);
         System.out.println("        🐬[Controller] getMyChatrooms return => " + chatroomSearchService.getChatroomListByMemberId(memberId));
-        return chatroomSearchService.getChatroomListByMemberId(memberId);
+        List<ChatroomDto> chatroomDtos = chatroomSearchService.getChatroomListByMemberId(memberId);
+
+        // 채팅방 조회시 채팅방 참여멤버수도 함께조회
+        if(!chatroomDtos.isEmpty()){
+            for(ChatroomDto chatroomDto : chatroomDtos){
+                List<ChatEntranceDto> chatEntrances = chatroomService.getChatEntranceListByChatroom(chatroomDto);
+
+                chatroomDto.setChatroomEntrancesSize(chatEntrances.size());
+            }
+        }
+        return chatroomDtos;
     }
 
     /**

--- a/src/main/java/com/kube/noon/chat/domain/ChatEntrance.java
+++ b/src/main/java/com/kube/noon/chat/domain/ChatEntrance.java
@@ -24,6 +24,7 @@ public class ChatEntrance {
 //    private int chatroomId;
 //    ////////////
 
+    // Chatroom 이 삭제될 때 ChatEntrance 도 삭제되도록
     @ManyToOne
     @JoinColumn(name = "chatroom_id", nullable = false)
     private Chatroom chatroom;

--- a/src/main/java/com/kube/noon/chat/domain/Chatroom.java
+++ b/src/main/java/com/kube/noon/chat/domain/Chatroom.java
@@ -42,6 +42,6 @@ public class Chatroom {
     @Column(name = "chatroom_dajung_temp_min")
     private Float chatroomMinTemp;
 
-    @OneToMany(mappedBy = "chatroom", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "chatroom", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatEntrance> chatEntranceList;
 }

--- a/src/main/java/com/kube/noon/chat/dto/ChatroomDto.java
+++ b/src/main/java/com/kube/noon/chat/dto/ChatroomDto.java
@@ -1,5 +1,6 @@
 package com.kube.noon.chat.dto;
 
+import com.kube.noon.chat.domain.ChatroomType;
 import com.kube.noon.member.domain.Member;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,8 +17,9 @@ public class ChatroomDto {
     private String chatroomName;
     private String chatroomCreatorId;
     private Member chatroomCreator;
-    private String chatroomType;
+    private ChatroomType chatroomType;
     private int buildingId;
-
+    
     private String invitedMemberId;
+    private int chatroomEntrancesSize; // 채팅방 참여멤버수를 채팅방에 저장
 }

--- a/src/main/java/com/kube/noon/chat/exceptions/ChatroomAutoDeleteFailException.java
+++ b/src/main/java/com/kube/noon/chat/exceptions/ChatroomAutoDeleteFailException.java
@@ -1,0 +1,17 @@
+package com.kube.noon.chat.exceptions;
+
+import com.kube.noon.chat.domain.Chatroom;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class ChatroomAutoDeleteFailException extends RuntimeException {
+
+    public ChatroomAutoDeleteFailException(final String message) {
+        super(message); // 부모 타입인 RuntimeException 의 메시지 생성자를 호출
+    }
+
+}
+

--- a/src/main/java/com/kube/noon/chat/exceptions/ChatroomGlobalExceptionHandler.java
+++ b/src/main/java/com/kube/noon/chat/exceptions/ChatroomGlobalExceptionHandler.java
@@ -1,0 +1,49 @@
+package com.kube.noon.chat.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class ChatroomGlobalExceptionHandler {
+
+    @ExceptionHandler(ChatroomNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<Map<String, Object>> handleChatroomNotFoundException(ChatroomNotFoundException ex) {
+        // 예외를 로그로 기록
+        System.err.println("Chatroom not found: " + ex.getMessage());
+
+        // 응답 객체 생성
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("timestamp", LocalDateTime.now());
+        responseBody.put("status", HttpStatus.NOT_FOUND.value());
+        responseBody.put("error", "Not Found");
+        responseBody.put("message", ex.getMessage());
+
+        // chatroomNotFoundException 이 발생했을 때 404 NotFound 와 함께
+        return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(ChatroomAutoDeleteFailException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<Map<String, Object>> handleChatroomAutoDeleteFaileException(ChatroomAutoDeleteFailException ex) {
+        // 예외를 로그로 기록
+        System.err.println("Chatroom not found: " + ex.getMessage());
+
+        // 응답 객체 생성
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("timestamp", LocalDateTime.now());
+        responseBody.put("status", HttpStatus.NOT_FOUND.value());
+        responseBody.put("error", "Not Found");
+        responseBody.put("message", ex.getMessage());
+
+        // chatroomNotFoundException 이 발생했을 때 404 NotFound 와 함께
+        return new ResponseEntity<>(responseBody, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/kube/noon/chat/exceptions/ChatroomNotFoundException.java
+++ b/src/main/java/com/kube/noon/chat/exceptions/ChatroomNotFoundException.java
@@ -1,0 +1,17 @@
+package com.kube.noon.chat.exceptions;
+
+import com.kube.noon.chat.domain.Chatroom;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class ChatroomNotFoundException extends RuntimeException {
+
+    public ChatroomNotFoundException(final String message) {
+        super(message); // 부모 타입인 RuntimeException 의 메시지 생성자를 호출
+    }
+
+}
+

--- a/src/main/java/com/kube/noon/chat/repository/ChatEntranceRepository.java
+++ b/src/main/java/com/kube/noon/chat/repository/ChatEntranceRepository.java
@@ -13,24 +13,24 @@ import java.util.List;
 public interface ChatEntranceRepository extends JpaRepository<ChatEntrance, Integer> {
 
     // 채팅멤버 ID를 기반으로 채팅멤버를 불러옴(추방이 되지 않은 채팅방 회원들만 불러옴)
-    @Query("SELECT ce FROM ChatEntrance ce WHERE ce.chatroomMemberId = :chatroomMemberId AND ce.kicked = false")
+    @Query("SELECT ce FROM ChatEntrance ce WHERE ce.chatroomMemberId = :chatroomMemberId AND ce.kicked = false AND ce.chatroom.activated = true")
     List<ChatEntrance> getChatEntrancesByChatroomMemberId(String chatroomMemberId);
 
     // 채팅방의 채팅멤버를 불러옴(추방이 되지 않은 유저들만 불러온다)
-    @Query("SELECT ce FROM ChatEntrance ce WHERE ce.chatroom = :chatroom AND ce.kicked = false")
+    @Query("SELECT ce FROM ChatEntrance ce WHERE ce.chatroom = :chatroom AND ce.kicked = false AND ce.chatroom.activated = true")
     List<ChatEntrance> findChatEntrancesByChatroom(Chatroom chatroom);
 
-    // 아직 공부안댐 (Commented by GDP)
+    // 채팅방ID를 기반으로 채팅멤버리스트를 불러옴
     @Query("""
         SELECT ce FROM ChatEntrance ce
-        WHERE ce.chatroom.chatroomId = :chatroomId
+        WHERE ce.chatroom.chatroomId = :chatroomId AND ce.chatroom.activated = true
         """)
     List<ChatEntrance> findChatEntranceListByChatroomId(Integer chatroomId);
 
     // 채팅방ID와 채팅방멤버ID에 해당하는 chatEntrance 의 kicked 속성을 0으로 업데이트
     @Transactional
     @Modifying
-    @Query("UPDATE ChatEntrance ce SET ce.kicked = true WHERE ce.chatroom = :chatroom AND ce.chatroomMemberId = :chatroomMemberId")
+    @Query("UPDATE ChatEntrance ce SET ce.kicked = true WHERE ce.chatroom = :chatroom AND ce.chatroomMemberId = :chatroomMemberId AND ce.chatroom.activated = true")
     int kickMember(@Param("chatroom") Chatroom chatroom, @Param("chatroomMemberId") String chatroomMemberId);
 
     // kicked 속성이 0인 ChatEntrance를 조회

--- a/src/main/java/com/kube/noon/chat/repository/ChatroomRepository.java
+++ b/src/main/java/com/kube/noon/chat/repository/ChatroomRepository.java
@@ -2,6 +2,7 @@ package com.kube.noon.chat.repository;
 
 import com.kube.noon.chat.domain.ChatEntrance;
 import com.kube.noon.chat.domain.Chatroom;
+import com.kube.noon.chat.domain.ChatroomType;
 import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,6 +17,13 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Integer> {
     // 기본적인 CRUD 메서드는 JpaRepository가 제공
     // 추가적인 커스텀 메서드를 정의할 수 있음
 
+
+    /**
+     * 주어진 buildingId에 속하고 activated가 true인 Chatroom을 조회합니다.
+     *
+     * @param buildingId 건물 ID
+     * @return 해당 건물에 속한 활성화된 Chatroom 목록
+     */
     @Query("""
             SELECT c FROM Chatroom c
             WHERE c.building.buildingId = :buildingId
@@ -23,6 +31,14 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Integer> {
             """)
     List<Chatroom> findByBuildingId(int buildingId);
 
+
+    /**
+     * 주어진 buildingId와 chatroomName을 포함하는 활성화된 Chatroom을 조회합니다.
+     *
+     * @param buildingId 건물 ID
+     * @param searchKeywordChatroom 검색할 채팅방 이름 키워드
+     * @return 검색 조건에 맞는 활성화된 Chatroom 목록
+     */
     @Query("""
             SELECT cr FROM Chatroom cr
             WHERE :buildingId = cr.building.buildingId
@@ -31,6 +47,13 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Integer> {
             """)
     List<Chatroom> findByBuildingIdAndChatroomNameContaining(int buildingId, String searchKeywordChatroom);
 
+
+    /**
+     * chatroomName을 포함하는 활성화된 Chatroom을 조회합니다.
+     *
+     * @param searchKeywordChatroom 검색할 채팅방 이름 키워드
+     * @return 검색 조건에 맞는 활성화된 Chatroom 목록
+     */
     @Query("""
             SELECT c FROM Chatroom c
             WHERE c.chatroomName LIKE CONCAT('%', :searchKeywordChatroom, '%')
@@ -38,6 +61,14 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Integer> {
             """)
     List<Chatroom> findByChatroomNameContaining(String searchKeywordChatroom);
 
+
+    /**
+     * chatroomName을 포함하는 활성화된 GROUP_CHATTING 타입의 Chatroom을 페이지네이션하여 조회합니다.
+     *
+     * @param chatroomName 검색할 채팅방 이름 키워드
+     * @param pageable 페이지네이션 정보
+     * @return 검색 조건에 맞는 활성화된 Chatroom 페이지
+     */
     @Query("""
             SELECT cr FROM Chatroom cr
             WHERE cr.chatroomName LIKE CONCAT('%', :chatroomName, '%')
@@ -46,6 +77,41 @@ public interface ChatroomRepository extends JpaRepository<Chatroom, Integer> {
             """)
     Page<Chatroom> findByChatroomNameContaining(@Param("chatroomName") String chatroomName, Pageable pageable);
 
+
+    /**
+     * 주어진 chatroomId에 해당하는 Chatroom을 비활성화합니다.
+     *
+     * @param chatroomId 채팅방 ID
+     */
+    @Transactional
+    @Modifying
+    @Query("UPDATE Chatroom c SET c.activated = false WHERE c.chatroomId = :chatroomId")
     void deleteChatroomByChatroomId(int chatroomId);
+
+
+    /**
+     * 주어진 chatroomId에 해당하는 활성화된 Chatroom을 조회합니다.
+     *
+     * @param chatroomId 채팅방 ID
+     * @return 해당 채팅방 ID에 맞는 활성화된 Chatroom
+     */
+    @Query("""
+            SELECT c FROM Chatroom c
+            WHERE c.chatroomId = :chatroomId
+                AND c.activated = TRUE
+            """)
     Chatroom findChatroomByChatroomId(int chatroomId);
+
+
+    /**
+     * GROUP_CHATTING 방을 모두 비활성화합니다.
+     *
+     * @param chatroomType 채팅방 타입 (예: GROUP_CHATTING)
+     * @return 비활성화된 채팅방의 수
+     */
+    @Transactional
+    @Modifying
+    @Query("UPDATE Chatroom c SET c.activated = false WHERE c.chatroomType = :chatroomType")
+    int deactivateByChatroomType(ChatroomType chatroomType);
+
 }

--- a/src/main/java/com/kube/noon/chat/service/ChatroomService.java
+++ b/src/main/java/com/kube/noon/chat/service/ChatroomService.java
@@ -26,6 +26,13 @@ public interface ChatroomService {
     public String deleteChatroom(int chatroomId) throws Exception;
 
     /**
+     * Job 의 내용을 일정주기로 반복실행하는 스케쥴러, ChatroomSchedularConfig 에서 정의한 DeleteChatroomJob의 실제 실행 내용
+     * @return
+     * @throws Exception
+     */
+    public int scheduledDeleteGroupChatrooms() throws Exception;
+
+    /**
      * 채팅방 추방
      * @param chatroomId
      * @param memberId

--- a/src/main/java/com/kube/noon/chat/service/DeleteChatroomsJob.java
+++ b/src/main/java/com/kube/noon/chat/service/DeleteChatroomsJob.java
@@ -1,0 +1,33 @@
+package com.kube.noon.chat.service;
+
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * ChatroomSchedularConfig 에서 설정한 DeleteChatroomJob 을 구현함
+ */
+@Component
+public class DeleteChatroomsJob implements Job {
+
+    @Autowired
+    private ChatroomService chatroomService;
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+
+        System.out.println("Deleting expired chat rooms..."); // 콘솔에 출력 (실제 삭제 로직을 여기에 구현)
+
+        int AutoDeletedChatroomsSize = 0;
+        try {
+            AutoDeletedChatroomsSize = chatroomService.scheduledDeleteGroupChatrooms();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        if (AutoDeletedChatroomsSize > 0) {
+            System.out.println("Deleted " + AutoDeletedChatroomsSize + " expired chat rooms.");
+        }
+    }
+}

--- a/src/main/java/com/kube/noon/chat/serviceImpl/ChatroomSearchServiceImpl.java
+++ b/src/main/java/com/kube/noon/chat/serviceImpl/ChatroomSearchServiceImpl.java
@@ -99,7 +99,7 @@ public class ChatroomSearchServiceImpl implements ChatroomSearchService {
         dto.setChatroomName(chatroom.getChatroomName());
         dto.setChatroomMinTemp(chatroom.getChatroomMinTemp());
         dto.setChatroomCreator(chatroom.getChatroomCreator());
-        dto.setChatroomType(chatroom.getChatroomType().toString()); // Enum 값을 문자열로 변환하여 설정
+        dto.setChatroomType(chatroom.getChatroomType()); // Enum 값을 문자열로 변환하여 설정
         return dto;
     }
 

--- a/src/main/java/com/kube/noon/common/security/AccessDefinition.java
+++ b/src/main/java/com/kube/noon/common/security/AccessDefinition.java
@@ -107,6 +107,8 @@ public class AccessDefinition {
             "/chatMatching/newChatApplyList",
             "/chatMatching/getChatApply",
 
+            // Chat Admin (여기 뭐하는애들인지 물어보기 to.GODGDP)
+
             // Building Profile
             "/buildingProfile/deleteSubscription",
             "/buildingProfile/addSubscription",

--- a/src/main/java/com/kube/noon/config/ChatroomSchedularConfig.java
+++ b/src/main/java/com/kube/noon/config/ChatroomSchedularConfig.java
@@ -1,0 +1,55 @@
+package com.kube.noon.config;
+
+import com.kube.noon.chat.service.DeleteChatroomsJob;
+import org.quartz.*;
+import org.quartz.impl.JobDetailImpl;
+import org.quartz.impl.triggers.SimpleTriggerImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Date;
+
+@Configuration
+public class ChatroomSchedularConfig {
+
+
+    /**
+     * Job: Quartz에서 실행할 작업을 정의합니다. Job 인터페이스를 구현한 클래스입니다.
+     * 여기서 채팅방 삭제 클래스 'DeleteChatroomJob' 을 연결시키고 있습니다.
+     * @return
+     */
+    @Bean
+    public JobDetail deleteChatRoomsJobDetail() {
+        JobDetailImpl jobDetail = new JobDetailImpl(); // JobDetailImpl은 JobDetail 인터페이스를 구현하는 여러 클래스 중 하나
+        jobDetail.setJobClass(DeleteChatroomsJob.class); // 작업이 실행될 때 수행할 로직을 포함하는 클래스
+        jobDetail.setJobDataMap(new JobDataMap()); // 작업 실행 시 필요한 데이터를 전달할 수 있는 맵 (현재는 비어있음)
+        jobDetail.setKey(new JobKey("deleteChatRoomsJob")); // 작업을 고유하게 식별하는 키
+        jobDetail.setDurability(true);
+        // Quartz에서 Job의 내구성을 true로 설정해야 합니다. Job이 트리거 없이도 스케줄러에 의해 유지되도록 설정하는 것입니다.
+
+        /**
+         * 만약 Durability 를 true 로 하지 않는다면?
+         * Quartz 스케줄러는 트리거가 없는 Job을 내구성이 없다고 간주하여 삭제합니다.
+         * 이로 인해 스프링 컨텍스트에서 해당 Job의 Bean을 생성하려 할 때, 스케줄러에서 해당 Job을 찾을 수 없어 오류가 발생합니다.
+         */
+        return jobDetail;
+    }
+
+    /**
+     * Trigger: 언제(Job의 실행 시점) 작업이 실행될지를 정의합니다.
+     * CronTrigger나 SimpleTrigger 등을 사용할 수 있습니다.
+     * @param deleteChatRoomsJobDetail
+     * @return
+     */
+    @Bean
+    public SimpleTriggerImpl deleteChatRoomsTrigger(JobDetail deleteChatRoomsJobDetail) {
+        SimpleTriggerImpl trigger = new SimpleTriggerImpl();
+        trigger.setJobKey(deleteChatRoomsJobDetail.getKey()); // Job키를 받기
+        trigger.setRepeatInterval(3600*30); // 1시간 간격 (밀리초 단위)
+        trigger.setRepeatCount(SimpleTrigger.REPEAT_INDEFINITELY); // 무한 반복
+        trigger.setKey(new TriggerKey("deleteChatRoomsTrigger"));
+        trigger.setStartTime(new Date()); // 트리거 시작 시간 설정
+        return trigger;
+    }
+
+}


### PR DESCRIPTION
## 요약
채팅방 자동삭제에 대한 로직을 만듦

## 변경 사항 설명
1) 채팅방 폭파 관련 로직
- 서버에서 채팅방 자동삭제 (activated 를 0으로 만듦)
- 다음 자동삭제까지 남은 시간(트리거 예정시간 - 현재 서버시간)을 클라이언트에 리턴
- 채팅방 조회시 activated 가 1인것만 조회하도록 함

2) 내 채팅목록 조회할 때 chatEntrances 의 수도 조회하여 채팅방마다 입장한 사람도 볼 수 있도록함

3) 코드 리뷰 받은 예외 처리 부분(500 -> 40x), 채팅타입 (String -> chatroomType) 변경


## 관련 이슈 및 참고 자료
(작성한 이슈를 작성하고 추가로 이해를 위한 참고자료가 있다면 공유 부탁드립니다)
