### PR TITLE
fix: 건물명으로 건물명 대신 도로명주소가 뜨던 거 수정

### DIFF
--- a/src/main/java/com/kube/noon/places/repository/PlacesNaverMapsApiRepositoryImpl.java
+++ b/src/main/java/com/kube/noon/places/repository/PlacesNaverMapsApiRepositoryImpl.java
@@ -171,7 +171,14 @@ public class PlacesNaverMapsApiRepositoryImpl implements PlacesRepository {
             JSONObject land = result.getJSONObject("land");
             String name = land.getString("name");
             String number = land.getString("number1");
-            return findByPlaceName(name + " " + number).get(0);
+            log.trace("land={}", land);
+            Place byRoadAddr = findByPlaceName(name + " " + number).get(0);
+            return Place.builder()
+                    .roadAddress(byRoadAddr.getRoadAddress())
+                    .latitude(byRoadAddr.getLatitude())
+                    .longitude(byRoadAddr.getLongitude())
+                    .placeName(land.getJSONObject("addition0").getString("value"))
+                    .build();
         } catch (URISyntaxException e) {
             throw new InvalidDataAccessResourceUsageException("URI syntax error for Naver Maps", e); // TODO
         }


### PR DESCRIPTION
## 요약
건물명이 도로명 주소가 되던 시절이 있었으나 이젠 아니다

## 변경 사항 설명
![image](https://github.com/kuberMAPtes/noon-main-api-server/assets/60085941/8a60444b-4cd4-44c9-9c17-d942fc8fe242)

이젠 건물명으로 데이터가 전송된다. 그러나 개중에 건물명이 없는 건물이 있다. (아마 원래 있는데 네이버 Geocode API에서 제공 안 해 주는 듯하다) 그래서 이걸 어떻게 해야 할지 생각해 봐야 한다.

## 관련 이슈 및 참고 자료
Issue: #195