### PR TITLE
fix : 도로명주소 조회 기능별 구분

### DIFF
--- a/src/main/java/com/kube/noon/building/repository/BuildingProfileRepository.java
+++ b/src/main/java/com/kube/noon/building/repository/BuildingProfileRepository.java
@@ -25,7 +25,7 @@ public interface BuildingProfileRepository extends JpaRepository<Building, Integ
     @Query("SELECT b FROM Building b WHERE b.profileActivated = true")
     List<Building> findActivatedBuildings();
 
-    @Query("SELECT b FROM Building b WHERE b.roadAddr = :roadAddr")
+    @Query("SELECT b FROM Building b WHERE b.roadAddr = :roadAddr AND b.profileActivated = TRUE")
     Building findBuildingProfileByRoadAddr(String roadAddr);
 
     @Query("SELECT b FROM Building b WHERE b.roadAddr = :roadAddr AND b.profileActivated = false")

--- a/src/main/java/com/kube/noon/building/service/BuildingProfileServiceImpl.java
+++ b/src/main/java/com/kube/noon/building/service/BuildingProfileServiceImpl.java
@@ -181,7 +181,7 @@ public class BuildingProfileServiceImpl implements BuildingProfileService {
 
         log.info("해당 도로명 주소로 조회={}", roadAddr);
 
-        Building building = buildingProfileRepository.findBuildingProfileByRoadAddr(roadAddr);
+        Building building = buildingProfileRepository.findAppliedBuildingByRoadAddr(roadAddr);
 
         if(building==null){
             log.info("처음 신청된 건물={}", roadAddr);


### PR DESCRIPTION
## 요약
도로명 주소로 조회하는 기능을 activated에 따라 구분했습니다

## 변경 사항 설명
건물 등록 신청에서는 profileActivated가 false인 데이터가 필요하고,
지도 쪽에서는 true인 데이터가 필요하기 때문입니다.

## 관련 이슈 및 참고 자료
