### PR TITLE
feat : 댓글 관련 수정 사항 추가, 이벤트 피드에 대한 테이블 추가 및 이에 대한 로직 추가

### DIFF
--- a/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
+++ b/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
@@ -257,7 +257,7 @@ public class FeedRestController {
 
     @Operation(summary = "피드 댓글 추가", description = "하나의 피드에 댓글을 추가합니다.")
     @PostMapping("/addFeedComment")
-    public int addFeedComment(@RequestBody FeedCommentDto feedCommentDto) {
+    public FeedCommentDto addFeedComment(@RequestBody FeedCommentDto feedCommentDto) {
         return feedSubService.addFeedComment(feedCommentDto);
     }
 

--- a/src/main/java/com/kube/noon/feed/domain/FeedEvent.java
+++ b/src/main/java/com/kube/noon/feed/domain/FeedEvent.java
@@ -1,0 +1,28 @@
+package com.kube.noon.feed.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "feed_event")
+public class FeedEvent {
+
+    @Id
+    @Column(name = "feed_id")
+    private int feedId;
+
+    @Column(name = "event_date", nullable = false)
+    private LocalDateTime eventDate;
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "feed_id")
+    private Feed feed;
+}

--- a/src/main/java/com/kube/noon/feed/domain/FeedEvent.java
+++ b/src/main/java/com/kube/noon/feed/domain/FeedEvent.java
@@ -20,9 +20,4 @@ public class FeedEvent {
 
     @Column(name = "event_date", nullable = false)
     private LocalDateTime eventDate;
-
-    @OneToOne
-    @MapsId
-    @JoinColumn(name = "feed_id")
-    private Feed feed;
 }

--- a/src/main/java/com/kube/noon/feed/dto/FeedCommentDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedCommentDto.java
@@ -19,6 +19,7 @@ public class FeedCommentDto {
     private int feedId;
     private int commentId;
     private String memberId;
+    private String memberNickname;
     private String memberProfile;
     private String commentText;
     private LocalDateTime writtenTime;
@@ -29,6 +30,7 @@ public class FeedCommentDto {
                 .feedId(feedComment.getFeed().getFeedId())
                 .commentId(feedComment.getCommentId())
                 .memberId(feedComment.getMember().getMemberId())
+                .memberNickname(feedComment.getMember().getNickname())
                 .memberProfile(feedComment.getMember().getProfilePhotoUrl())
                 .commentText(feedComment.getCommentText())
                 .writtenTime(feedComment.getWrittenTime())

--- a/src/main/java/com/kube/noon/feed/dto/FeedDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedDto.java
@@ -48,7 +48,8 @@ public class FeedDto {
     private List<TagDto> tags;
     private List<TagFeedDto> tagFeeds;
     private List<String> updateTagList; // 피드를 추가할 때 피드 내용을 가져올 리스트
-
+    private LocalDateTime eventDate;  // 이벤트 피드일 때 가져올 날짜
+    
     public static FeedDto toDto(Feed feed) {
         // NullPointException
         Building building = feed.getBuilding();

--- a/src/main/java/com/kube/noon/feed/dto/FeedEventDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedEventDto.java
@@ -1,0 +1,31 @@
+package com.kube.noon.feed.dto;
+
+import com.kube.noon.feed.domain.Feed;
+import com.kube.noon.feed.domain.FeedEvent;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class FeedEventDto {
+    private int feedId;
+    private LocalDateTime eventDate;
+
+    public static FeedEventDto toDto(FeedEvent feedEvent) {
+        return FeedEventDto.builder()
+                .feedId(feedEvent.getFeedId())
+                .eventDate(feedEvent.getEventDate())
+                .build();
+    }
+
+    public static List<FeedEventDto> toDtoList(List<FeedEvent> feedEventList) {
+        return feedEventList.stream().map(FeedEventDto::toDto).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/kube/noon/feed/dto/FeedVotesDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedVotesDto.java
@@ -42,6 +42,8 @@ public class FeedVotesDto {
                 ", question : " + question +
                 ", options : " + options +
                 ", votes : " + votes +
-                ", voterIds : " + voterIds;
+                ", voterIds : " + voterIds +
+                ", memberId : " + memberId +
+                ", chosenOption : " + chosenOption;
     }
 }

--- a/src/main/java/com/kube/noon/feed/dto/UpdateFeedDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/UpdateFeedDto.java
@@ -4,6 +4,7 @@ import com.kube.noon.common.FeedCategory;
 import com.kube.noon.common.PublicRange;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -23,4 +24,5 @@ public class UpdateFeedDto {
     private PublicRange publicRange;
     private FeedCategory feedCategory;
     private List<String> updateTagList; // 피드를 수정할 때 태그 리스트를 가져올 리스트
+    private LocalDateTime eventDate;  // 이벤트 피드일 때 가져올 날짜
 }

--- a/src/main/java/com/kube/noon/feed/repository/FeedEventRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/FeedEventRepository.java
@@ -1,0 +1,14 @@
+package com.kube.noon.feed.repository;
+
+import com.kube.noon.feed.domain.FeedEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedEventRepository extends JpaRepository<FeedEvent, Integer> {
+
+    /**
+     * 이벤트 하나를 찾는다.
+     * @param feedId
+     * @return
+     */
+    FeedEvent findByFeedId(int feedId);
+}

--- a/src/main/java/com/kube/noon/feed/service/FeedSubService.java
+++ b/src/main/java/com/kube/noon/feed/service/FeedSubService.java
@@ -55,7 +55,7 @@ public interface FeedSubService {
     List<FeedCommentDto> getFeedCommentList(int feedId);
 
     // 피드에 댓글을 하나 추가한다.
-    int addFeedComment(FeedCommentDto feedCommentDto);
+    FeedCommentDto addFeedComment(FeedCommentDto feedCommentDto);
 
     // 댓글을 삭제한다.
     int deleteFeedComment(int commentId);

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
@@ -15,6 +15,7 @@ import com.kube.noon.feed.dto.TagDto;
 import com.kube.noon.feed.repository.*;
 import com.kube.noon.feed.service.FeedSubService;
 import com.kube.noon.member.domain.Member;
+import com.kube.noon.member.repository.MemberJpaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpHeaders;
@@ -40,6 +41,7 @@ public class FeedSubServiceImpl implements FeedSubService {
     private final TagRepository tagRepository;
     private final ZzimRepository zzimRepository;
     private final ObjectStorageAPI objectStorageAPI;
+    private final MemberJpaRepository memberJpaRepository;
     private final ObjectStorageAPIProfile objectStorageAPIProfile; // test
 
     @Override
@@ -244,10 +246,17 @@ public class FeedSubServiceImpl implements FeedSubService {
     }
 
     @Override
-    public int addFeedComment(FeedCommentDto feedCommentDto) {
+    public FeedCommentDto addFeedComment(FeedCommentDto feedCommentDto) {
         FeedComment addFeedComment = FeedCommentDto.toEntity(feedCommentDto);
         addFeedComment.setActivated(true);
-        return feedCommentRepository.save(addFeedComment).getCommentId();
+
+        Member member = memberJpaRepository.findById(feedCommentDto.getMemberId())
+                .orElseThrow(() -> new RuntimeException("Member not found"));
+        addFeedComment.setMember(member);
+
+        FeedComment savedFeedComment = feedCommentRepository.save(addFeedComment);
+        
+        return FeedCommentDto.toDto(feedCommentRepository.save(savedFeedComment));
     }
 
     @Override

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedVotesServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedVotesServiceImpl.java
@@ -63,7 +63,13 @@ public class FeedVotesServiceImpl implements FeedVotesService {
         if (feedVotes != null) {
             // 1. 투표자의 현황 갱신 및 추가하기
             Map<String, Integer> voterIds = feedVotes.getVoterIds();
+
+            // 회원 처리에 대한 null 처리
             String memberId = feedVotesDto.getMemberId();
+            if(memberId == null || memberId == "") {
+                return null;
+            }
+
             int chosenOption = feedVotesDto.getChosenOption();
             int optionSize = feedVotesDto.getOptions().size();
             voterIds.put(memberId, chosenOption);
@@ -80,9 +86,6 @@ public class FeedVotesServiceImpl implements FeedVotesService {
             return null;
         }
     }
-
-
-
 
     @Override
     public FeedVotesDto getVoteById(int feedId) {

--- a/src/test/java/com/kube/noon/feed/service/TestFeedSubServiceImpl.java
+++ b/src/test/java/com/kube/noon/feed/service/TestFeedSubServiceImpl.java
@@ -242,7 +242,7 @@ public class TestFeedSubServiceImpl {
                 .writtenTime(LocalDateTime.now())
                 .activated(true)
                 .build();
-        int commentId = feedSubServiceImpl.addFeedComment(feedCommentDto);
+        int commentId = feedSubServiceImpl.addFeedComment(feedCommentDto).getCommentId();
 
         FeedComment feedComment = feedCommentRepository.findByCommentId(commentId);
 


### PR DESCRIPTION
## 요약
댓글 관련한 로직을 조금 수정했습니다.  
그리고 이벤트 피드를 구현하기 위해 간단한 테이블을 추가했고, 이에 대한 로직을 작성 중입니다.

## 변경 사항 설명
### 1. 댓글 관련 로직 추가
댓글 작성 시 닉네임을 가져오기 위해 로직을 수정했습니다.

### 2. 테이블 추가
```
# feed_event
CREATE TABLE feed_event (
    feed_id INT PRIMARY KEY,
    event_date DATETIME NOT NULL,
    FOREIGN KEY (feed_id) REFERENCES feed(feed_id)
);
```
이벤트 지정 날짜를 저장하는 테이블을 하나 추가했습니다.

### 3. 로직 추가
위 테이블을 사용한 로직을 추가했습니다. 일반 피드 관련 기능에 추가하였으며, 요구사항에 따라 계속 추가할 예정입니다. 

## 관련 이슈 및 참고 자료
없음
