### PR TITLE
fix : 좋아요, 북마크, 목록 보기에 대한 로직 재구성

### DIFF
--- a/src/main/java/com/kube/noon/common/zzim/Zzim.java
+++ b/src/main/java/com/kube/noon/common/zzim/Zzim.java
@@ -22,8 +22,8 @@ public class Zzim {
     @Column(name = "feed_id")
     private Integer feedId;
 
-    @Column(name = "building_id", nullable = false)
-    private int buildingId;
+    @Column(name = "building_id")
+    private Integer buildingId;
 
     @Column(name = "subscription_provider_id", length = 20)
     private String subscriptionProviderId;

--- a/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
+++ b/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
@@ -33,8 +33,9 @@ public class FeedRestController {
     @GetMapping("/getFeedListByMember")
     public List<FeedSummaryDto> getMemberFeedList(
             @Parameter(description = "회원 ID") @RequestParam String memberId,
+            @Parameter(description = "로그인한 회원 ID") @RequestParam String loginMemberId,
             @Parameter(description = "가져올 페이지(default = 1)") @RequestParam(required = false, defaultValue = "1") int page) {
-        List<FeedSummaryDto> feedListByMember = feedService.getFeedListByMember(memberId, page - 1, PAGE_SIZE);
+        List<FeedSummaryDto> feedListByMember = feedService.getFeedListByMember(memberId, loginMemberId, page - 1, PAGE_SIZE);
 
         return feedListByMember;
     }
@@ -54,8 +55,9 @@ public class FeedRestController {
     @GetMapping("/getFeedListByMemberLike")
     public List<FeedSummaryDto> getMemberLikeFeedList(
             @Parameter(description = "회원 ID") @RequestParam String memberId,
+            @Parameter(description = "로그인한 회원 ID") @RequestParam String loginMemberId,
             @Parameter(description = "가져올 페이지(default = 1)") @RequestParam(required = false, defaultValue = "1") int page) {
-        List<FeedSummaryDto> feedListByMemberLike = feedService.getFeedListByMemberLike(memberId, page - 1, PAGE_SIZE);
+        List<FeedSummaryDto> feedListByMemberLike = feedService.getFeedListByMemberLike(memberId, loginMemberId, page - 1, PAGE_SIZE);
 
         return feedListByMemberLike;
     }
@@ -64,8 +66,9 @@ public class FeedRestController {
     @GetMapping("/getFeedListByMemberBookmark")
     public List<FeedSummaryDto> getBookmarkFeedList(
             @Parameter(description = "회원 ID") @RequestParam String memberId,
+            @Parameter(description = "로그인한 회원 ID") @RequestParam String loginMemberId,
             @Parameter(description = "가져올 페이지(default = 1)") @RequestParam(required = false, defaultValue = "1") int page) {
-        List<FeedSummaryDto> feedListByMemberBookmark = feedService.getFeedListByMemberBookmark(memberId, page - 1, PAGE_SIZE);
+        List<FeedSummaryDto> feedListByMemberBookmark = feedService.getFeedListByMemberBookmark(memberId, loginMemberId, page - 1, PAGE_SIZE);
 
         return feedListByMemberBookmark;
     }
@@ -74,8 +77,9 @@ public class FeedRestController {
     @GetMapping("/getFeedListByMemberSubscription")
     public List<FeedSummaryDto> getBuildingSubscriptionFeedList(
             @Parameter(description = "회원 ID") @RequestParam String memberId,
+            @Parameter(description = "로그인한 회원 ID") @RequestParam String loginMemberId,
             @Parameter(description = "가져올 페이지(default = 1)") @RequestParam(required = false, defaultValue = "1") int page) {
-        List<FeedSummaryDto> feedListByBuildingSubscription = feedService.getFeedListByBuildingSubscription(memberId, page - 1, PAGE_SIZE);
+        List<FeedSummaryDto> feedListByBuildingSubscription = feedService.getFeedListByBuildingSubscription(memberId, loginMemberId, page - 1, PAGE_SIZE);
 
         return feedListByBuildingSubscription;
     }

--- a/src/main/java/com/kube/noon/feed/dto/FeedSummaryDto.java
+++ b/src/main/java/com/kube/noon/feed/dto/FeedSummaryDto.java
@@ -50,7 +50,7 @@ public class FeedSummaryDto {
                 .writerNickname(feed.getWriter().getNickname())
                 .title(feed.getTitle())
                 .feedText(feed.getFeedText())
-                .buildingId(feed.getBuilding().getBuildingId())
+                .buildingId(feed.getBuilding() == null ? 0 : feed.getBuilding().getBuildingId())
                 .buildingName(feed.getBuilding().getBuildingName())
                 .writtenTime(feed.getWrittenTime())
                 .feedCategory(feed.getFeedCategory())

--- a/src/main/java/com/kube/noon/feed/service/FeedService.java
+++ b/src/main/java/com/kube/noon/feed/service/FeedService.java
@@ -18,7 +18,7 @@ import java.util.List;
 public interface FeedService {
     // 회원별 피드 목록을 가져온다,
     List<FeedSummaryDto> getFeedListByMember(String memberId);
-    List<FeedSummaryDto> getFeedListByMember(String memberId, int page, int pageSize);
+    List<FeedSummaryDto> getFeedListByMember(String memberId, String loginMemberId, int page, int pageSize);
 
     // 건물별 피드 목록을 가져온다. 필요에 따라 피드를 추천한다.
     List<FeedSummaryDto> getFeedListByBuilding(String memberId, int buildingId);
@@ -30,15 +30,15 @@ public interface FeedService {
 
     // 회원이 좋아요를 누른 피드 목록을 가져온다.
     List<FeedSummaryDto> getFeedListByMemberLike(String memberId);
-    List<FeedSummaryDto> getFeedListByMemberLike(String memberId, int page, int pageSize);
+    List<FeedSummaryDto> getFeedListByMemberLike(String memberId, String loginMemberId, int page, int pageSize);
 
     // 회원이 북마크를 누른 피드 목록을 가져온다.
     List<FeedSummaryDto> getFeedListByMemberBookmark(String memberId);
-    List<FeedSummaryDto> getFeedListByMemberBookmark(String memberId, int page, int pageSize);
+    List<FeedSummaryDto> getFeedListByMemberBookmark(String memberId, String loginMemberId, int page, int pageSize);
 
     // 회원이 건물을 구독한 피드 목록을 가져온다.
     List<FeedSummaryDto> getFeedListByBuildingSubscription(String memberId);
-    List<FeedSummaryDto> getFeedListByBuildingSubscription(String memberId, int page, int pageSize);
+    List<FeedSummaryDto> getFeedListByBuildingSubscription(String memberId, String loginMemberId, int page, int pageSize);
 
     // 건물 내 피드 중 확성기 관련 피드만 가져온다.
     List<FeedMegaphoneDto> getFeedListByBuildingAndMegaphone(int buildingId);

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
@@ -47,6 +47,8 @@ public class FeedServiceImpl implements FeedService {
 
     // FeedSumaryDto에 좋아요, 북마크 정보 저장
     private List<FeedSummaryDto> setFeedSummaryDtoLikeAndBookmark(String memberId, List<FeedSummaryDto> feedList) {
+        if(memberId == null) return feedList;
+
         List<Integer> zzimLikeList = zzimRepository.getFeedIdByMemberIdAndZzimType(memberId, ZzimType.LIKE);
         List<Integer> zzimBookmarkList = zzimRepository.getFeedIdByMemberIdAndZzimType(memberId, ZzimType.BOOKMARK);
 
@@ -97,7 +99,7 @@ public class FeedServiceImpl implements FeedService {
     }
 
     @Override
-    public List<FeedSummaryDto> getFeedListByMember(String memberId, int page, int pageSize) {
+    public List<FeedSummaryDto> getFeedListByMember(String memberId, String loginMemberId, int page, int pageSize) {
         Pageable pageable = PageRequest.of(page, pageSize);
 
         List<Feed> entities = feedRepository.findByWriterAndActivatedTrue(
@@ -105,7 +107,7 @@ public class FeedServiceImpl implements FeedService {
                 pageable
         );
 
-        List<FeedSummaryDto> feedListByMember = setFeedSummaryDtoLikeAndBookmark(memberId, FeedSummaryDto.toDtoList(entities));
+        List<FeedSummaryDto> feedListByMember = setFeedSummaryDtoLikeAndBookmark(loginMemberId, FeedSummaryDto.toDtoList(entities));
 
         return feedListByMember;
     }
@@ -192,14 +194,14 @@ public class FeedServiceImpl implements FeedService {
     }
 
     @Override
-    public List<FeedSummaryDto> getFeedListByMemberLike(String memberId, int page, int pageSize) {
+    public List<FeedSummaryDto> getFeedListByMemberLike(String memberId, String loginMemberId, int page, int pageSize) {
         Pageable pageable = PageRequest.of(page, pageSize);
 
         List<Feed> entites = feedRepository.findByMemberLikeFeed(
                 Member.builder().memberId(memberId).build(), pageable
         );
 
-        List<FeedSummaryDto> feedListByMemberLike = setFeedSummaryDtoLikeAndBookmark(memberId, FeedSummaryDto.toDtoList(entites));
+        List<FeedSummaryDto> feedListByMemberLike = setFeedSummaryDtoLikeAndBookmark(loginMemberId, FeedSummaryDto.toDtoList(entites));
 
         return feedListByMemberLike;
     }
@@ -218,14 +220,14 @@ public class FeedServiceImpl implements FeedService {
     }
 
     @Override
-    public List<FeedSummaryDto> getFeedListByMemberBookmark(String memberId, int page, int pageSize) {
+    public List<FeedSummaryDto> getFeedListByMemberBookmark(String memberId, String loginMemberId, int page, int pageSize) {
         Pageable pageable = PageRequest.of(page, pageSize);
 
         List<Feed> entites = feedRepository.findByMemberBookmarkFeed(
                 Member.builder().memberId(memberId).build(), pageable
         );
 
-        List<FeedSummaryDto> feedListByMemberBookmark = setFeedSummaryDtoLikeAndBookmark(memberId, FeedSummaryDto.toDtoList(entites));
+        List<FeedSummaryDto> feedListByMemberBookmark = setFeedSummaryDtoLikeAndBookmark(loginMemberId, FeedSummaryDto.toDtoList(entites));
 
         return feedListByMemberBookmark;
     }
@@ -244,14 +246,14 @@ public class FeedServiceImpl implements FeedService {
     }
 
     @Override
-    public List<FeedSummaryDto> getFeedListByBuildingSubscription(String memberId, int page, int pageSize) {
+    public List<FeedSummaryDto> getFeedListByBuildingSubscription(String memberId, String loginMemberId, int page, int pageSize) {
         Pageable pageable = PageRequest.of(page, pageSize);
 
         List<Feed> entites = feedRepository.findByMemberBuildingSubscription(
                 Member.builder().memberId(memberId).build(), pageable
         );
 
-        List<FeedSummaryDto> feedListByBuildingSubscription = setFeedSummaryDtoLikeAndBookmark(memberId, FeedSummaryDto.toDtoList(entites));
+        List<FeedSummaryDto> feedListByBuildingSubscription = setFeedSummaryDtoLikeAndBookmark(loginMemberId, FeedSummaryDto.toDtoList(entites));
 
         return feedListByBuildingSubscription;
     }

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
@@ -163,7 +163,7 @@ public class FeedSubServiceImpl implements FeedSubService {
                     .memberId(memberId)
                     .feedId(feedId)
                     .zzimType(ZzimType.LIKE)
-                    .buildingId(feed.getBuilding().getBuildingId())
+                    // .buildingId(feed.getBuilding().getBuildingId())
                     .subscriptionProviderId(null)
                     .activated(true)
                     .build();
@@ -181,12 +181,23 @@ public class FeedSubServiceImpl implements FeedSubService {
     public int deleteFeedLike(int feedId, String memberId) {
         List<Zzim> zzimLikeList = zzimRepository.findByFeedIdAndMemberIdAndZzimTypeOrderByZzimId(feedId, memberId, ZzimType.LIKE);
         Zzim deleteZzim = (zzimLikeList.isEmpty() ? null : zzimLikeList.get(0));
+        Feed feed = feedRepository.findByFeedId(feedId);
 
         if(deleteZzim != null) {
             deleteZzim.setActivated(false);
             return zzimRepository.save(deleteZzim).getZzimId();
         } else {
-            return -1; // error
+            // return -1; // error
+            // 새로 만들어서 취소하는 로직 구현
+            deleteZzim = Zzim.builder()
+                    .memberId(memberId)
+                    .feedId(feedId)
+                    .zzimType(ZzimType.LIKE)
+                    // .buildingId(feed.getBuilding().getBuildingId())
+                    .subscriptionProviderId(null)
+                    .activated(false)
+                    .build();
+            return zzimRepository.save(deleteZzim).getZzimId();
         }
     }
 
@@ -204,7 +215,7 @@ public class FeedSubServiceImpl implements FeedSubService {
                     .memberId(memberId)
                     .feedId(feedId)
                     .zzimType(ZzimType.BOOKMARK)
-                    .buildingId(feed.getBuilding().getBuildingId())
+                    // .buildingId(feed.getBuilding().getBuildingId())
                     .subscriptionProviderId(null)
                     .activated(true)
                     .build();
@@ -227,7 +238,16 @@ public class FeedSubServiceImpl implements FeedSubService {
             deleteZzim.setActivated(false);
             return zzimRepository.save(deleteZzim).getZzimId();
         } else {
-            return -1; // error
+            // 새로 만들어서 취소하는 로직 구현
+            deleteZzim = Zzim.builder()
+                    .memberId(memberId)
+                    .feedId(feedId)
+                    .zzimType(ZzimType.BOOKMARK)
+                    // .buildingId(feed.getBuilding().getBuildingId())
+                    .subscriptionProviderId(null)
+                    .activated(false)
+                    .build();
+            return zzimRepository.save(deleteZzim).getZzimId();
         }
     }
 


### PR DESCRIPTION
## 요약
좋아요, 북마크, 목록 보기에 대한 로직을 재구성했습니다.

## 변경 사항 설명
대표적으로 2가지가 변경되었습니다.
### 1. 좋아요, 북마크 삭제에 대한 예외 처리
컬럼에 관련 내용이 없으면 Exception이 나는 것을 대비하기 위해 따로 로직을 구성했습니다.

### 2. 목록 보기에 loginMemberId 요구 사항 추가
목록을 가져올 대상의 memberId와 로그인을 한 memberId를 구분하여 로직을 재구성했습니다.

## 관련 이슈 및 참고 자료
없음
