### PR TITLE
fix : 피드 첨부파일 가져오는 방식 추가, 피드 저장과 댓글 저장 시 시간 오차 해결

### DIFF
--- a/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
+++ b/src/main/java/com/kube/noon/feed/controller/FeedRestController.java
@@ -187,12 +187,20 @@ public class FeedRestController {
         return feedAttachmentDtoList;
     }
 
-    @Operation(summary = "피드의 첨부파일 하나 조회", description = "피드에 첨부된 파일 하나를 만듭니다.")
+    @Operation(summary = "피드의 첨부파일 하나 조회", description = "피드에 첨부된 파일 하나를 가져옵니다.")
     @GetMapping("/getFeedAttachment")
     public ResponseEntity<byte[]> getFeedAttachment(@Parameter(description = "첨부파일 ID") @RequestParam int attachmentId) {
         ResponseEntity<byte[]> resultEntity = feedSubService.getFeedAttachment(attachmentId);
 
         return resultEntity;
+    }
+
+    @Operation(summary = "피드의 첨부파일에 대한 정보(dto) 하나 조회", description = "피드에 첨부된 파일에 대한 정보를 가져옵니다.")
+    @GetMapping("/getFeedAttachmentDto")
+    public FeedAttachmentDto getFeedAttachmentDto(@Parameter(description = "첨부파일 ID") @RequestParam int attachmentId) {
+        FeedAttachmentDto resultFeedAttachmentDto = feedSubService.getFeedAttachmentDto(attachmentId);
+
+        return resultFeedAttachmentDto;
     }
 
     @Operation(summary = "피드 내 첨부파일 추가", description = "피드에 첨부파일 하나를 추가합니다.")

--- a/src/main/java/com/kube/noon/feed/repository/FeedRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/FeedRepository.java
@@ -26,6 +26,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
      * @return List<Feed>
      */
     List<Feed> findByActivatedTrue();
+
     List<Feed> findByActivatedTrue(Pageable pageable);
 
     /**
@@ -35,13 +36,16 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
      * @return List<Feed>
      */
     List<Feed> findByWriterAndActivatedTrue(Member writer);
+
     List<Feed> findByWriterAndActivatedTrue(Member writer, Pageable pageable);
+
     /**
      * 건물별로 작성된 피드를 가져온다. 단, 활성화가 된 피드만 가져온다.
      *
      * @return List<Feed>
      */
     List<Feed> findByBuildingAndActivatedTrue(Building building);
+
     List<Feed> findByBuildingAndActivatedTrue(Building building, Pageable pageable);
 
     /**
@@ -56,6 +60,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
      * @return Feed 회원의 메인 피드를 가져온다.
      */
     List<Feed> findByWriterAndMainActivatedTrue(Member writer);
+
     List<Feed> findByWriterAndMainActivatedTrue(Member writer, Pageable pageable);
 
     /**
@@ -80,7 +85,8 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     /**
      * 하나의 빌딩 내에서 회원이 좋아요를 누른 피드 목록을 가져온다.
-     * @param member 멤버의 아이디를 가져온다
+     *
+     * @param member   멤버의 아이디를 가져온다
      * @param building 빌딩 번호를 가져온다.
      * @return 피드 목록 결과를 가져온다.
      */
@@ -161,7 +167,8 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     /**
      * 빌딩 내 건물 중 member가 좋아요를 누른 내용을 우선 정렬한다.
-     * @param member 좋아요를 누른 회원
+     *
+     * @param member   좋아요를 누른 회원
      * @param building 건물 번호
      * @return
      */
@@ -201,27 +208,33 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     /**
      * 제목이나 내용을 통해 피드를 검색할 수 있도록 합니다.
+     *
      * @param keyword 검색할 keyword를 입력합니다.
      * @return List<Feed>
      */
     List<Feed> findByFeedTextContainingIgnoreCase(String keyword);
+
     List<Feed> findByTitleContainingIgnoreCase(String keyword);
 
     /**
      * 제목이나 내용을 통해 피드를 검색할 수 있도록 합니다.
      * 이 메서드를 이용하여 통합 검색과 페이징이 가능합니다.
+     *
      * @param keyword
      * @param pageable
      */
     @Query("SELECT f FROM Feed f WHERE f.title LIKE %:#{#keyword}% OR f.feedText LIKE %:#{#keyword}%")
     List<Feed> searchFeedByKeyword(String keyword, Pageable pageable);
 
-
-
     /**
      * 가장 최근에 추가한  feedId를 가져온다.
+     *
      * @return FeedId
      */
     @Query("SELECT MAX(fa.feedId) FROM Feed fa")
     Integer findMaxId();
+
+    /**
+     *
+     */
 }

--- a/src/main/java/com/kube/noon/feed/repository/FeedRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/FeedRepository.java
@@ -115,7 +115,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     /**
      * 회원이 북마크를 한 피드 목록을 가져온다. 단, 활성화가 된 피드만 가져온다.
      *
-     * @param writer Member 객체를 받는다.
+     * @param member Member 객체를 받는다.
      * @return List<Feed>
      */
     @Query("""

--- a/src/main/java/com/kube/noon/feed/service/FeedSubService.java
+++ b/src/main/java/com/kube/noon/feed/service/FeedSubService.java
@@ -22,8 +22,11 @@ public interface FeedSubService {
     // 첨부파일 타입별로 첨부파일을 가져온다.
     List<FeedAttachmentDto> getFeedAttachementListByFileType(FileType fileType);
 
-    // 첨부파일 하나를 가져온다.
+    // 첨부파일 하나를 가져온다. : 바이너리 데이터
     ResponseEntity<byte[]> getFeedAttachment(int attachmentId);
+
+    // 첨부파일 데이터 하나를 가져온다.
+    FeedAttachmentDto getFeedAttachmentDto(int attachmentId);
 
     // 피드와 연관있는 첨부파일 목록을 가져온다.
     List<FeedAttachmentDto> getFeedAttachmentList(int feedId);

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedServiceImpl.java
@@ -25,6 +25,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;;
 import java.util.List;
 import java.util.Random;
@@ -281,6 +283,10 @@ public class FeedServiceImpl implements FeedService {
     @Transactional
     @Override
     public int addFeed(FeedDto feedDto) {
+        // 한국 시간으로 변경
+        ZonedDateTime kstDateTime = feedDto.getWrittenTime().atZone(ZoneId.of("UTC")).withZoneSameInstant(ZoneId.of("Asia/Seoul"));
+        feedDto.setWrittenTime(kstDateTime.toLocalDateTime());
+
         Feed addFeed = FeedDto.toEntity(feedDto);
         if(addFeed.getFeedCategory() == FeedCategory.NOTICE) {
             addFeed.setBuilding(null);

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
@@ -85,16 +85,23 @@ public class FeedSubServiceImpl implements FeedSubService {
         }
     }
 
-    // 파일 확장자를 기반으로 MIME 타입을 반환하는 메소드
+    @Override
+    public FeedAttachmentDto getFeedAttachmentDto(int attachmentId) {
+        FeedAttachmentDto feedAttachmentDto = FeedAttachmentDto.toDto(feedAttachmentRepository.findByAttachmentId(attachmentId));
+
+        return feedAttachmentDto;
+    }
+
+    // 파일 확장자를 기반으로 MIME 타입을 반환하는 메소드 : 한 번 더 걸러주는 역할
     private MediaType getMediaType(String fileName) {
         String[] parts = fileName.split("\\.");
         String extension = parts[parts.length - 1].toLowerCase(); // 파일 확장자를 소문자로 변환하여 비교
 
         switch (extension) {
             case "jpg": case "jpeg":
-            case "png": case "gif":
+            case "png": case "gif": case "webp":
                 return MediaType.IMAGE_JPEG; // 이미지 파일인 경우
-            case "mp4":
+            case "mp4": case "mp3":
                 return MediaType.valueOf("video/mp4"); // 동영상 파일인 경우
             default:
                 return MediaType.APPLICATION_OCTET_STREAM; // 기타 파일은 바이너리 스트림으로 처리
@@ -118,18 +125,22 @@ public class FeedSubServiceImpl implements FeedSubService {
                 for(MultipartFile file : multipartFileList) {
                     String originalFileName = file.getOriginalFilename();
 
-                    // Object Storage에 넣기
-                    String Url = objectStorageAPI.putObject(originalFileName, file);
-                    // String Url = objectStorageAPIProfile.putObject(originalFileName, file); // test
+                    FileType fileType = getFileType(originalFileName);
+                    // 정해진 확장자만 저장한다.
+                    if(fileType != null) {
+                        // Object Storage에 넣기
+                        String Url = objectStorageAPI.putObject(originalFileName, file);
+                        // String Url = objectStorageAPIProfile.putObject(originalFileName, file); // test
 
-                    // DB에 넣기
-                    feedAttachmentRepository.save(FeedAttachment.builder()
-                            .feed(Feed.builder().feedId(feedId).build())
-                            .fileUrl(Url)
-                            .fileType(FileType.PHOTO) // 임시
-                            .blurredFileUrl(null)
-                            .activated(true)
-                            .build());
+                        // DB에 넣기
+                        feedAttachmentRepository.save(FeedAttachment.builder()
+                                .feed(Feed.builder().feedId(feedId).build())
+                                .fileUrl(Url)
+                                .fileType(fileType)
+                                .blurredFileUrl(null)
+                                .activated(true)
+                                .build());
+                    }
                 }
             }
         } catch (Exception e) {
@@ -139,6 +150,22 @@ public class FeedSubServiceImpl implements FeedSubService {
         return feedId;
     }
 
+    // 파일 확장자를 기반으로 사진/동영상을 판단한다.
+    private FileType getFileType(String fileName) {
+        String[] parts = fileName.split("\\.");
+        String extension = parts[parts.length - 1].toLowerCase(); // 파일 확장자를 소문자로 변환하여 비교
+
+        switch (extension) {
+            case "jpg": case "jpeg":
+            case "png": case "gif": case "webp":
+                return FileType.PHOTO; // 이미지 파일인 경우
+            case "mp4": case "mp3":
+                return FileType.VIDEO; // 동영상 파일인 경우
+            default:
+                return null; // 기타 파일일 경우  null 반환
+        }
+    }
+    
     @Transactional
     @Override
     public int deleteFeedAttachment(int attachmentId) {

--- a/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
+++ b/src/main/java/com/kube/noon/feed/service/impl/FeedSubServiceImpl.java
@@ -27,6 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 @Service
@@ -294,6 +296,10 @@ public class FeedSubServiceImpl implements FeedSubService {
 
     @Override
     public FeedCommentDto addFeedComment(FeedCommentDto feedCommentDto) {
+        // 한국 시간으로 변경
+        ZonedDateTime kstDateTime = feedCommentDto.getWrittenTime().atZone(ZoneId.of("UTC")).withZoneSameInstant(ZoneId.of("Asia/Seoul"));
+        feedCommentDto.setWrittenTime(kstDateTime.toLocalDateTime());
+
         FeedComment addFeedComment = FeedCommentDto.toEntity(feedCommentDto);
         addFeedComment.setActivated(true);
 


### PR DESCRIPTION
## 요약
피드 첨부파일을 가져오는 방식 중 dto를 통한 방식을 추가했고, 시간 저장 시 한국 표준시로 저장하도록 변경하였습니다.

## 변경 사항 설명
### 1. 피드 첨부파일 가져오기
본래, Object Storage가 비공개 설정이었을 때 따로 다른 과정을 가져서 첨부파일 정보를 가져왔는데 이제 그럴 필요가 없어서 dto의 url를 가져오기 위해 따로 `Controller` 및 `Service`를 추가했습니다.

### 2.  시간 수정
React에서 `new Date()` 값을 받으면 Spring에서 이를 한국 표준시로 바꾸는 로직을 추가했습니다.

## 관련 이슈 및 참고 자료
없음
