### PR TITLE
feat: 알림 수신 여부 확인

### DIFF
--- a/src/main/java/com/kube/noon/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/kube/noon/notification/service/NotificationServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Slf4j
 @Service
@@ -24,8 +25,14 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     public void sendNotification(NotificationDto dto) {
-        Member receiver = this.memberService.findMemberById(dto.getReceiverId())
-                .orElseThrow(() -> new RuntimeException("그런 회원 없습니다: " + dto.getReceiverId())); // TODO: 구체적인 예외
+        Member receiver;
+        try {
+            receiver = this.memberService.findMemberById(dto.getReceiverId())
+                    .orElseThrow(() -> new NoSuchElementException("그런 회원 없습니다: " + dto.getReceiverId()));
+        } catch (NoSuchElementException e) {
+            log.warn("대상 회원이 존재하지 않음", e);
+            return;
+        }
         if (receiver.getReceivingAllNotificationAllowed() == null || !receiver.getReceivingAllNotificationAllowed()) {
             return;
         }

--- a/src/main/java/com/kube/noon/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/kube/noon/notification/service/NotificationServiceImpl.java
@@ -26,6 +26,9 @@ public class NotificationServiceImpl implements NotificationService {
     public void sendNotification(NotificationDto dto) {
         Member receiver = this.memberService.findMemberById(dto.getReceiverId())
                 .orElseThrow(() -> new RuntimeException("그런 회원 없습니다: " + dto.getReceiverId())); // TODO: 구체적인 예외
+        if (receiver.getReceivingAllNotificationAllowed() == null || !receiver.getReceivingAllNotificationAllowed()) {
+            return;
+        }
         saveNotification(receiver, dto);
         this.transmissionAgent.send(receiver, dto.getNotificationText(), dto.getNotificationType());
     }


### PR DESCRIPTION
## 요약
알림 수신 대상의 알림 수신 설정이 "수신하지 않음"일 경우 알림을 보내지 않음

## 변경 사항 설명
- NotificationServiceImpl에 알림 수신 대상의 알림 수신 여부 체크
- 알림 수신 대상이 존재하지 않을 회원일 경우 알림을 보내지 않음

## 관련 이슈 및 참고 자료
Issue: #231
