### PR TITLE
refactor : Check Subscriber List PublicRange

### DIFF
--- a/src/main/java/com/kube/noon/building/controller/BuildingProfileRestController.java
+++ b/src/main/java/com/kube/noon/building/controller/BuildingProfileRestController.java
@@ -145,9 +145,17 @@ public class BuildingProfileRestController {
     /**
      * 건물 아이디로 구독자 목록 가져오기
      */
-    @GetMapping("/getSubscribers")
+    @RequestMapping(value = "/getSubscribers", params = "buildingId")
     public List<MemberDto> getSubscribers(@RequestParam("buildingId") int buildingId) {
         return buildingProfileService.getSubscribers(buildingId);
+    }
+
+    /**
+     * 건물 아이디, 회원 아이디로 해당 회원에게 공개된 구독자 목록 조회
+     */
+    @RequestMapping(value = "/getSubscribers", params = {"buildingId", "viewerId"})
+    public List<SubscriberDto> getSubscribers(@RequestParam("buildingId") int buildingId, @RequestParam("viewerId") String viewerId) {
+        return buildingProfileService.getSubscribers(buildingId, viewerId);
     }
 
     /**

--- a/src/main/java/com/kube/noon/building/dto/SubscriberDto.java
+++ b/src/main/java/com/kube/noon/building/dto/SubscriberDto.java
@@ -1,0 +1,14 @@
+package com.kube.noon.building.dto;
+
+import com.kube.noon.member.dto.member.MemberDto;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SubscriberDto {
+
+    private MemberDto member;
+    private boolean isVisible;
+
+}

--- a/src/main/java/com/kube/noon/building/service/BuildingProfileService.java
+++ b/src/main/java/com/kube/noon/building/service/BuildingProfileService.java
@@ -14,6 +14,7 @@ public interface BuildingProfileService {
     BuildingZzimDto addSubscription(String memberId, int buildingId);
     BuildingDto addSubscription(BuildingApplicantDto buildingApplicantDto);
     List<MemberDto> getSubscribers(int buildingId);
+    List<SubscriberDto> getSubscribers(int buildingId, String viewerId);
     List<MemberDto> getSubscribers(String roadAddr);
     BuildingZzimDto deleteSubscription(String memberId, int buildingId);
     List<BuildingDto> addSubscriptionFromSomeone(String memberId, String someoneId);

--- a/src/main/java/com/kube/noon/building/service/BuildingProfileServiceImpl.java
+++ b/src/main/java/com/kube/noon/building/service/BuildingProfileServiceImpl.java
@@ -1,20 +1,17 @@
 package com.kube.noon.building.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kube.noon.building.domain.Building;
 import com.kube.noon.building.dto.*;
 import com.kube.noon.building.exception.NotRegisteredBuildingException;
 import com.kube.noon.building.repository.BuildingSummaryRepository;
 import com.kube.noon.building.repository.mapper.BuildingProfileMapper;
 import com.kube.noon.building.repository.BuildingProfileRepository;
-import com.kube.noon.building.service.buildingwiki.BuildingWikiEmptyServiceImpl;
-import com.kube.noon.building.service.buildingwiki.BuildingWikiRestTemplateServiceImpl;
 import com.kube.noon.chat.domain.Chatroom;
 import com.kube.noon.chat.dto.ChatroomDto;
 import com.kube.noon.chat.dto.LiveliestChatroomDto;
 import com.kube.noon.chat.repository.ChatroomRepository;
-import com.kube.noon.chat.serviceImpl.ChatroomSearchServiceImpl;
+import com.kube.noon.chat.service.ChatroomSearchService;
+import com.kube.noon.common.PublicRange;
 import com.kube.noon.common.binder.DtoEntityBinder;
 import com.kube.noon.common.constant.PagingConstants;
 import com.kube.noon.common.zzim.Zzim;
@@ -24,7 +21,10 @@ import com.kube.noon.feed.domain.Feed;
 import com.kube.noon.feed.repository.FeedRepository;
 import com.kube.noon.member.binder.mapper.member.MemberDtoBinderImpl;
 import com.kube.noon.member.dto.member.MemberDto;
+import com.kube.noon.member.dto.memberRelationship.MemberRelationshipDto;
+import com.kube.noon.member.enums.RelationshipType;
 import com.kube.noon.member.repository.impl.MemberRepositoryImpl;
+import com.kube.noon.member.service.impl.MemberServiceImpl;
 import com.kube.noon.places.domain.Position;
 import com.kube.noon.places.domain.PositionRange;
 import com.kube.noon.places.dto.PlaceDto;
@@ -75,7 +75,8 @@ public class BuildingProfileServiceImpl implements BuildingProfileService {
     private final SortHandlerMethodArgumentResolverCustomizer sortCustomizer;
     private final MemberRepositoryImpl memberRepositoryImpl;
     private final MemberDtoBinderImpl memberDtoBinderImpl;
-    private final ChatroomSearchServiceImpl chatroomSearchService;
+    private final ChatroomSearchService chatroomSearchService;
+    private final MemberServiceImpl memberService;
 
     private static final int CHART_DATA_LIMIT = 20;
 
@@ -177,6 +178,67 @@ public class BuildingProfileServiceImpl implements BuildingProfileService {
             subscribers.add(memberDtoBinderImpl.toDto(memberRepositoryImpl.findMemberById(memberId).orElseThrow()));
         }
         log.info("Building subscribers={}",subscribers);
+
+        return subscribers;
+    }
+
+
+    /**
+     * 건물 아이디, 회원 아이디로 해당 회원에게 공개된 구독자 목록 조회
+     */
+    @Override
+    public List<SubscriberDto> getSubscribers(int buildingId, String viewerId) {
+
+        List<SubscriberDto> subscribers = new ArrayList<>();
+        PublicRange memberPublicRange;
+
+        //구독자들의 공개 여부 체크
+        List<String> subscriberIds = zzimRepository.findMemberIdsByBuildingId(buildingId);
+        log.info(buildingId+"의 전체 구독자 목록:"+subscriberIds);
+        for(String memberId : subscriberIds){
+
+            MemberDto member = memberDtoBinderImpl.toDto(memberRepositoryImpl.findMemberById(memberId).orElseThrow());
+            memberPublicRange = member.getBuildingSubscriptionPublicRange();
+            SubscriberDto subscriberDto = SubscriberDto.builder().member(member).build();
+
+            log.info(member.getMemberId()+"의 공개범위는 "+memberPublicRange);
+
+            if(viewerId.equals(memberId)){
+                subscriberDto.setVisible(true);
+            }else{
+                if( memberPublicRange == PublicRange.PRIVATE ){
+
+                    subscriberDto.setVisible(false);
+
+                }else if(memberPublicRange == PublicRange.FOLLOWER_ONLY){
+
+                    MemberRelationshipDto memberRelationshipDto = memberService.findMemberRelationship(viewerId, memberId,RelationshipType.FOLLOW);
+
+                    if(memberRelationshipDto==null){
+                        subscriberDto.setVisible(false);
+                    }else{
+                        subscriberDto.setVisible(
+                                memberRelationshipDto.getRelationshipType() == RelationshipType.FOLLOW ? true : false
+                        );
+                    }
+
+                }else if(memberPublicRange == PublicRange.MUTUAL_ONLY){
+
+                    subscriberDto.setVisible(
+                            memberService.isMutualFollow(viewerId, memberId)
+                    );
+
+                }else{
+                    subscriberDto.setVisible(true);
+                }
+            }
+
+            log.info("subscriberDto: "+subscriberDto);
+            subscribers.add(subscriberDto);
+            log.info("추가된 목록:"+subscribers);
+
+        }
+        log.info("Building subscribers with isVisible={}", subscribers);
 
         return subscribers;
     }

--- a/src/main/java/com/kube/noon/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/kube/noon/member/service/impl/MemberServiceImpl.java
@@ -269,7 +269,7 @@ public class MemberServiceImpl implements MemberService {
                 });
     }
 
-    private boolean isMutualFollow(String fromId, String memberId) {
+    public boolean isMutualFollow(String fromId, String memberId) {
         MemberRelationshipDto relationship1 = findMemberRelationship(fromId, memberId, RelationshipType.FOLLOW);
         MemberRelationshipDto relationship2 = findMemberRelationship(memberId, fromId, RelationshipType.FOLLOW);
 


### PR DESCRIPTION
## 요약
건물 프로필에서 구독자 목록을 가져올 때 공개 범위를 체크합니다.

## 변경 사항 설명
현재 로그인한 회원(Viewer)이 조회 가능한 구독자(Member) 목록만을 표시합니다. 
따라서 파라미터에 viewerId가 추가되었습니다.
viewerId가 memberId와 같다면 무조건 조회할 수 있도록 했습니다.

Viewer와 Member의 맞팔 관계를 체크할 때 MemberServiceImpl내의 메서드(서비스가 아닌)를 써야하기 때문에 접근 제한자를 수정했습니다. 추후 구조 자체를 리팩토링 할 수 있을 것 같습니다.

또한 findMemberRelationship에서 null발생 가능성이 있으므로  getSubscribers에서 일단은 명시적으로 null체크를 했습니다. 
추후에 Member쪽에서 Optional사용 등으로 리팩토링 할 수 있을 것 같습니다.
 
## 관련 이슈 및 참고 자료
#228 