### PR TITLE
Hyeon jun0527/#178/view refactoring

### DIFF
--- a/src/main/java/com/kube/noon/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/kube/noon/member/service/impl/MemberServiceImpl.java
@@ -234,10 +234,9 @@ public class MemberServiceImpl implements MemberService {
             log.info("차단된 회원: FromID={}, MemberID={}", fromId, memberId);
             return Optional.of(new ProfileAccessResultDto(false, "차단한 회원의 프로필입니다.", null));
         }
-
-        MemberRelationshipDto memberRelationshipDto = findMemberRelationship(fromId, memberId,RelationshipType.FOLLOW);
         return memberRepository.findMemberById(memberId)
                 .map(findedMember -> {
+
                     PublicRange profilePublicRange = findedMember.getMemberProfilePublicRange();
                     log.info("프로필 공개 범위 확인: MemberID={}, 공개 범위={}", memberId, profilePublicRange);
                     switch (profilePublicRange) {
@@ -248,6 +247,10 @@ public class MemberServiceImpl implements MemberService {
                             log.info("프로필 비공개: 접근 불가");
                             return new ProfileAccessResultDto(false, "비공개된 프로필입니다.", null);
                         case FOLLOWER_ONLY:
+                            MemberRelationshipDto memberRelationshipDto = findMemberRelationship(fromId, memberId,RelationshipType.FOLLOW);
+                            if(memberRelationshipDto == null){
+                                return new ProfileAccessResultDto(false, "팔로워만 볼 수 있는 프로필입니다.", null);
+                            }
                             log.info("팔로워 전용 프로필: 접근 가능 여부={}", memberRelationshipDto.getRelationshipType() == RelationshipType.FOLLOW);
                             if (memberRelationshipDto.getRelationshipType() == RelationshipType.FOLLOW) {
                                 return new ProfileAccessResultDto(true, "팔로워로서 프로필에 접근할 수 있습니다.", createMemberProfileDto(findedMember, memberId));

--- a/src/test/java/com/kube/noon/member/service/TestMemberService.java
+++ b/src/test/java/com/kube/noon/member/service/TestMemberService.java
@@ -92,8 +92,24 @@ public class TestMemberService {
     @DisplayName("회원 프로필  찾기 테스트")
     void findMemberProfileById() {
         log.info("회원 프로필 찾기 테스트!@#!@");
-        System.out.println(memberService.findMemberProfileById("member_1","member_1"));
-        assertThat(memberService.findMemberProfileById("member_1","member_1")).isNotNull();
+        System.out.println(memberService.findMemberProfileById("member_1","member_10"));
+        assertThat(memberService.findMemberProfileById("member_1","member_10").isCanAccess()).isTrue();
+
+        System.out.println(memberService.findMemberProfileById("member_10","member_1"));
+        assertThat(memberService.findMemberProfileById("member_10","member_1").isCanAccess()).isFalse();
+
+        System.out.println(memberService.findMemberProfileById("member_1","member_100"));
+        assertThat(memberService.findMemberProfileById("member_1","member_100").isCanAccess()).isFalse();
+
+        System.out.println(memberService.findMemberProfileById("admin_1","member_1"));
+        assertThat(memberService.findMemberProfileById("admin_1","member_1").isCanAccess()).isTrue();
+
+        System.out.println(memberService.findMemberProfileById("admin_1","member_10"));
+        assertThat(memberService.findMemberProfileById("admin_1","member_10").isCanAccess()).isTrue();
+
+        System.out.println(memberService.findMemberProfileById("admin_1","member_100"));
+        assertThat(memberService.findMemberProfileById("admin_1","member_100").isCanAccess()).isTrue();
+
     }
 
     //이거 private함수를 테스트해보고 주석처리 한 것 입니다.


### PR DESCRIPTION
## 요약
회원 관계에 따른 접근제한에 관련된 메서드 에러 해결

## 변경 사항 설명
회원 관계에 따른 접근제한에 관련된 메서드에서 null처리를 안해서 memberRelaitionshipDto가 null이면 생기는 에러를 해결함

## 관련 이슈 및 참고 자료
(작성한 이슈를 작성하고 추가로 이해를 위한 참고자료가 있다면 공유 부탁드립니다)
