### PR TITLE
chore: 채팅방 활발함 기준 인하

### DIFF
--- a/src/main/java/com/kube/noon/building/service/BuildingProfileServiceImpl.java
+++ b/src/main/java/com/kube/noon/building/service/BuildingProfileServiceImpl.java
@@ -387,13 +387,13 @@ public class BuildingProfileServiceImpl implements BuildingProfileService {
             }
 
             int liveliness;
-            if (messageCount < 200) {
+            if (messageCount < 10) {
                 liveliness = 1;
-            } else if (messageCount < 400) {
+            } else if (messageCount < 20) {
                 liveliness = 2;
-            } else if (messageCount < 600) {
+            } else if (messageCount < 30) {
                 liveliness = 3;
-            } else if (messageCount < 800) {
+            } else if (messageCount < 40) {
                 liveliness = 4;
             } else {
                 liveliness = 5;


### PR DESCRIPTION
## 요약
서비스 이용자가 거의 없는 상태에서 채팅방 활발함을 보여주기 위해 기준을 상당히 내렸습니다.

## 변경 사항 설명
채팅방 활발함 기준 인하

1단계: 10개 미만
2단계: 10~20개
3단계: 20~30개
4단계: 30~40개
5단계: 40개 이상

## 관련 이슈 및 참고 자료
