### PR TITLE
fix : 인기 태그와 건물 구독 별 피드 목록 정렬 수정

### DIFF
--- a/src/main/java/com/kube/noon/feed/repository/FeedRepository.java
+++ b/src/main/java/com/kube/noon/feed/repository/FeedRepository.java
@@ -147,14 +147,14 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     @Query("""
             SELECT f FROM Feed f 
             INNER JOIN Zzim z ON f.building.buildingId = z.buildingId 
-            WHERE z.zzimType = 'SUBSCRIPTION' AND z.memberId = :#{#member.memberId} AND f.activated = true AND z.activated = true ORDER BY z.feedId DESC
+            WHERE z.zzimType = 'SUBSCRIPTION' AND z.memberId = :#{#member.memberId} AND f.activated = true AND z.activated = true ORDER BY f.writtenTime DESC
            """)
     List<Feed> findByMemberBuildingSubscription(@Param("member") Member member);
 
     @Query("""
             SELECT f FROM Feed f 
             INNER JOIN Zzim z ON f.building.buildingId = z.buildingId 
-            WHERE z.zzimType = 'SUBSCRIPTION' AND z.memberId = :#{#member.memberId} AND f.activated = true AND z.activated = true ORDER BY z.feedId DESC
+            WHERE z.zzimType = 'SUBSCRIPTION' AND z.memberId = :#{#member.memberId} AND f.activated = true AND z.activated = true ORDER BY f.writtenTime DESC
            """)
     List<Feed> findByMemberBuildingSubscription(@Param("member") Member member, Pageable pageable);
 

--- a/src/main/resources/mybatis-mapper/feed/FeedMapper.xml
+++ b/src/main/resources/mybatis-mapper/feed/FeedMapper.xml
@@ -54,7 +54,8 @@
             (SELECT t.tag_text FROM tag t
             INNER JOIN tag_feed tf ON t.tag_id = tf.tag_id
             INNER JOIN feed f ON tf.feed_id = f.feed_id) r
-        GROUP BY r.tag_text limit 5;
+        GROUP BY r.tag_text
+        ORDER BY count DESC limit 5;
     </select>
 
     <select id = "getFeedPopularity" parameterType="int" resultMap = "feedPopularityMap">


### PR DESCRIPTION
## 요약
테스트 중 발견한 버그를 수정합니다.

## 변경 사항 설명
1. 인기 태그는 제대로 정렬이 되지 않아 역순으로 확인하는 버그 수정
2. 건물 구독은 최신 피드가 뜨도록 수정

## 관련 이슈 및 참고 자료
없음
